### PR TITLE
Fix layout-gap/flex-order responsive issues

### DIFF
--- a/projects/libs/flex-layout/flex/flex-order/flex-order.ts
+++ b/projects/libs/flex-layout/flex/flex-order/flex-order.ts
@@ -64,6 +64,14 @@ export class FlexOrderDirective extends BaseDirective2 implements OnChanges {
   }
 
   protected override styleCache = flexOrderCache;
+
+  override updateWithValue(input: string) {
+    super.updateWithValue(input);
+
+    if (this.parentElement) {
+      this.marshal.triggerUpdate(this.parentElement, 'layout-gap');
+    }
+  }
 }
 
 const flexOrderCache: Map<string, StyleDefinition> = new Map();

--- a/projects/libs/flex-layout/flex/layout-gap/layout-gap.spec.ts
+++ b/projects/libs/flex-layout/flex/layout-gap/layout-gap.spec.ts
@@ -481,6 +481,62 @@ describe('layout-gap directive', () => {
       expectEl(nodes[2]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
     });
 
+    it('should remove gaps with responsive layout change', () => {
+      let template = `
+        <div fxLayout="row" fxLayout.xs="column" fxLayoutGap.xs="24px">
+          <div fxFlex></div>
+          <div fxFlex></div>
+          <div fxFlex></div>
+        </div>
+      `;
+      createTestComponent(template);
+      let nodes = queryFor(fixture, '[fxFlex]');
+
+      mediaController.activate('md');
+      fixture.detectChanges();
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-bottom': '24px' }, styler);
+      expectEl(nodes[1]).not.toHaveStyle({ 'margin-bottom': '24px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
+
+      mediaController.activate('xs');
+      fixture.detectChanges();
+      expect(nodes.length).toEqual(3);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-bottom': '24px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-bottom': '24px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
+
+      mediaController.activate('md');
+      fixture.detectChanges();
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-bottom': '24px' }, styler);
+      expectEl(nodes[1]).not.toHaveStyle({ 'margin-bottom': '24px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
+    });
+
+    it('should add gap styles in proper order when order style is applied on responsive layout change', () => {
+      let template = `
+        <div fxLayout="row" fxLayoutAlign="space-evenly center" fxLayout.xs="column" fxLayoutGap.xs="20px">
+          <div fxFlex fxFlexOrder.xs="3"></div>
+          <div fxFlex fxFlexOrder.xs="2"></div>
+          <div fxFlex fxFlexOrder.xs="1"></div>
+        </div>
+      `;
+      createTestComponent(template);
+      let nodes = queryFor(fixture, '[fxFlex]');
+
+      mediaController.activate('md');
+      fixture.detectChanges();
+      expect(nodes.length).toEqual(3);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
+      expectEl(nodes[1]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
+
+      mediaController.activate('xs');
+      fixture.detectChanges();
+      expectEl(nodes[2]).toHaveStyle({ 'margin-bottom': '20px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-bottom': '20px' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
+    });
+
     it('should work with dynamic fxHide', () => {
       let template = `
         <div fxLayout="row" fxLayoutGap="10px">

--- a/projects/libs/flex-layout/flex/layout-gap/layout-gap.ts
+++ b/projects/libs/flex-layout/flex/layout-gap/layout-gap.ts
@@ -190,12 +190,20 @@ export class LayoutGapDirective
    */
   protected onLayoutChange(matcher: ElementMatcher) {
     const layout: string = matcher.value;
+
     // Make sure to filter out 'wrap' option
-    const direction = layout.split(' ');
-    this.layout = direction[0];
-    if (!LAYOUT_VALUES.find((x) => x === this.layout)) {
-      this.layout = 'row';
+    let newDirection = layout.split(' ')[0];
+
+    if (!LAYOUT_VALUES.find((x) => x === newDirection)) {
+      newDirection = 'row';
     }
+
+    // Clear the previous style before we change the layout
+    if (this.layout && this.layout !== newDirection){
+      this.clearStyles();
+    }
+
+    this.layout = newDirection;
     this.triggerUpdate();
   }
 


### PR DESCRIPTION
Fixes #28.

**Changes**

- [Update parent layout-gap when applying order directive](https://github.com/ngbracket/ngx-layout/commit/7339b8ef3ec1dd0f2a3bc421605517a2909b8989)
- [Clear layout-gap style when changing layout](https://github.com/ngbracket/ngx-layout/commit/7eab70b7bbb45ace6de4f823e5c62d7cedeb00fd)

**Tests**

- [Add tests for layout-gap responsive scenarios](https://github.com/ngbracket/ngx-layout/commit/bcaad02f1fea1e6358032542c8757b5d59d0dc67)