### PR TITLE
refactor: resolve `variable-name` TSLint error

### DIFF
--- a/projects/libs/flex-layout/core/match-media/mock/mock-match-media.ts
+++ b/projects/libs/flex-layout/core/match-media/mock/mock-match-media.ts
@@ -250,8 +250,7 @@ export class MockMediaQueryList extends EventTarget implements MediaQueryList {
 /**
  * Pre-configured provider for MockMatchMedia
  */
-// tslint:disable-line:variable-name
-export const MockMatchMediaProvider = {
+export const MockMatchMediaProvider = { // tslint:disable-line:variable-name
   provide: MatchMedia,
   useClass: MockMatchMedia,
 };


### PR DESCRIPTION
The `disable-line` TSLint annotation was placed incorrectly, twice.