### PR TITLE
fix(flex-layout): use aliased imports from primary entry point to secondary entry point

### DIFF
--- a/projects/libs/flex-layout/provider.ts
+++ b/projects/libs/flex-layout/provider.ts
@@ -1,12 +1,12 @@
 import { Provider } from '@angular/core';
-import { BreakPoint } from './core/breakpoints';
 import {
+  BreakPoint,
   BREAKPOINT,
   DEFAULT_CONFIG,
   LAYOUT_CONFIG,
   LayoutConfigOptions,
   SERVER_TOKEN,
-} from './core/tokens';
+} from '@ngbracket/ngx-layout/core';
 
 export function provideFlexLayout(
   configOptions: LayoutConfigOptions,


### PR DESCRIPTION
Fix `build` CI job.

We can't use relative imports between package entry points.