### PR TITLE
ci(github): use environment secret for publish job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,4 +180,6 @@ jobs:
       - name: Stamp
         run: pnpm stamp
       - name: Publish snapshots
+        env:
+          FLEX_LAYOUT_BUILDS_TOKEN: ${{ secrets.FLEX_LAYOUT_BUILDS_TOKEN }}
         run: ./scripts/deploy/publish-build-artifacts.sh --no-build


### PR DESCRIPTION
## CI

Map `FLEX_LAYOUT_BUILDS_TOKEN` secret to environment variable in the `publish_snapshots` job.