### PR TITLE
Fix/override inputs

### DIFF
--- a/projects/libs/flex-layout/extended/style/style.ts
+++ b/projects/libs/flex-layout/extended/style/style.ts
@@ -32,9 +32,34 @@ import {
   stringToKeyValue,
 } from './style-transforms';
 
-@Directive()
+const inputs = [
+  'ngStyle',
+  'ngStyle.xs',
+  'ngStyle.sm',
+  'ngStyle.md',
+  'ngStyle.lg',
+  'ngStyle.xl',
+  'ngStyle.lt-sm',
+  'ngStyle.lt-md',
+  'ngStyle.lt-lg',
+  'ngStyle.lt-xl',
+  'ngStyle.gt-xs',
+  'ngStyle.gt-sm',
+  'ngStyle.gt-md',
+  'ngStyle.gt-lg',
+];
+
+const selector = `
+  [ngStyle],
+  [ngStyle.xs], [ngStyle.sm], [ngStyle.md], [ngStyle.lg], [ngStyle.xl],
+  [ngStyle.lt-sm], [ngStyle.lt-md], [ngStyle.lt-lg], [ngStyle.lt-xl],
+  [ngStyle.gt-xs], [ngStyle.gt-sm], [ngStyle.gt-md], [ngStyle.gt-lg]
+`;
+
+@Directive({ selector, inputs })
 export class StyleDirective extends BaseDirective2 implements DoCheck {
   protected override DIRECTIVE_KEY = 'ngStyle';
+  protected override inputs = inputs;
   protected fallbackStyles: NgStyleMap;
   protected isServer: boolean;
 
@@ -113,33 +138,14 @@ export class StyleDirective extends BaseDirective2 implements DoCheck {
   }
 }
 
-const inputs = [
-  'ngStyle',
-  'ngStyle.xs',
-  'ngStyle.sm',
-  'ngStyle.md',
-  'ngStyle.lg',
-  'ngStyle.xl',
-  'ngStyle.lt-sm',
-  'ngStyle.lt-md',
-  'ngStyle.lt-lg',
-  'ngStyle.lt-xl',
-  'ngStyle.gt-xs',
-  'ngStyle.gt-sm',
-  'ngStyle.gt-md',
-  'ngStyle.gt-lg',
-];
 
-const selector = `
-  [ngStyle],
-  [ngStyle.xs], [ngStyle.sm], [ngStyle.md], [ngStyle.lg], [ngStyle.xl],
-  [ngStyle.lt-sm], [ngStyle.lt-md], [ngStyle.lt-lg], [ngStyle.lt-xl],
-  [ngStyle.gt-xs], [ngStyle.gt-sm], [ngStyle.gt-md], [ngStyle.gt-lg]
-`;
 
 /**
  * Directive to add responsive support for ngStyle.
  *
+ */
+/* @deprecated The DefaultStyleDirective will be removed in version 21.
+ * Use StyleDirective directly instead.
  */
 @Directive({ selector, inputs })
 export class DefaultStyleDirective extends StyleDirective implements DoCheck {

--- a/projects/libs/flex-layout/flex/flex-align/flex-align.ts
+++ b/projects/libs/flex-layout/flex/flex-align/flex-align.ts
@@ -61,6 +61,7 @@ const selector = `
 @Directive({ inputs, selector })
 export class FlexAlignDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'flex-align';
+  protected override inputs = inputs;
 
   constructor(
     elRef: ElementRef,

--- a/projects/libs/flex-layout/flex/flex-offset/flex-offset.ts
+++ b/projects/libs/flex-layout/flex/flex-offset/flex-offset.ts
@@ -77,6 +77,7 @@ const selector = `
 @Directive({ inputs, selector })
 export class FlexOffsetDirective extends BaseDirective2 implements OnChanges {
   protected override DIRECTIVE_KEY = 'flex-offset';
+  protected override inputs = inputs;
 
   constructor(
     elRef: ElementRef,

--- a/projects/libs/flex-layout/flex/flex-order/flex-order.ts
+++ b/projects/libs/flex-layout/flex/flex-order/flex-order.ts
@@ -45,6 +45,7 @@ const selector = `
 @Directive({ inputs, selector })
 export class FlexOrderDirective extends BaseDirective2 implements OnChanges {
   protected override DIRECTIVE_KEY = 'flex-order';
+  protected override inputs = inputs;
 
   constructor(
     elRef: ElementRef,

--- a/projects/libs/flex-layout/flex/flex/flex.ts
+++ b/projects/libs/flex-layout/flex/flex/flex.ts
@@ -235,6 +235,7 @@ const selector = `
 @Directive({ inputs, selector })
 export class FlexDirective extends BaseDirective2 implements OnInit {
   protected override DIRECTIVE_KEY = 'flex';
+  protected override inputs = inputs;
   protected direction?: string = undefined;
   protected wrap?: boolean = undefined;
 

--- a/projects/libs/flex-layout/flex/layout-align/layout-align.ts
+++ b/projects/libs/flex-layout/flex/layout-align/layout-align.ts
@@ -138,6 +138,7 @@ const selector = `
 @Directive({ inputs, selector })
 export class LayoutAlignDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'layout-align';
+  protected override inputs = inputs;
   protected layout = 'row'; // default flex-direction
   protected inline = false; // default inline value
 

--- a/projects/libs/flex-layout/flex/layout-gap/layout-gap.ts
+++ b/projects/libs/flex-layout/flex/layout-gap/layout-gap.ts
@@ -124,6 +124,7 @@ export class LayoutGapDirective
 {
   protected layout = 'row'; // default flex-direction
   protected override DIRECTIVE_KEY = 'layout-gap';
+  protected override inputs = inputs;
   protected observerSubject = new Subject<void>();
 
   /** Special accessor to query for all child 'element' nodes regardless of type, class, etc */

--- a/projects/libs/flex-layout/flex/layout/layout.ts
+++ b/projects/libs/flex-layout/flex/layout/layout.ts
@@ -65,6 +65,7 @@ const selector = `
 @Directive({ selector, inputs })
 export class LayoutDirective extends BaseDirective2 implements OnChanges {
   protected override DIRECTIVE_KEY = 'layout';
+  protected override inputs = inputs;
 
   constructor(
     elRef: ElementRef,

--- a/projects/libs/flex-layout/grid/align-columns/align-columns.ts
+++ b/projects/libs/flex-layout/grid/align-columns/align-columns.ts
@@ -50,6 +50,7 @@ const selector = `
 @Directive({ inputs, selector })
 export class GridAlignColumnsDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-align-columns';
+  protected override inputs = inputs;
 
   @Input('gdInline')
   get inline(): boolean {

--- a/projects/libs/flex-layout/grid/align-rows/align-rows.ts
+++ b/projects/libs/flex-layout/grid/align-rows/align-rows.ts
@@ -50,6 +50,7 @@ const selector = `
 @Directive({ selector, inputs })
 export class GridAlignRowsDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-align-rows';
+  protected override inputs = inputs;
 
   @Input('gdInline')
   get inline(): boolean {

--- a/projects/libs/flex-layout/grid/area/area.ts
+++ b/projects/libs/flex-layout/grid/area/area.ts
@@ -40,9 +40,10 @@ const selector = `
   [gdArea.gt-xs], [gdArea.gt-sm], [gdArea.gt-md], [gdArea.gt-lg]
 `;
 
-@Directive({ inputs, selector })
+@Directive({ selector, inputs })
 export class GridAreaDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-area';
+  protected override inputs = inputs;
 
   constructor(
     elRef: ElementRef,

--- a/projects/libs/flex-layout/grid/areas/areas.ts
+++ b/projects/libs/flex-layout/grid/areas/areas.ts
@@ -56,6 +56,7 @@ const selector = `
 @Directive({ selector, inputs })
 export class GridAreasDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-areas';
+  protected override inputs = inputs;
 
   @Input('gdInline')
   get inline(): boolean {

--- a/projects/libs/flex-layout/grid/auto/auto.ts
+++ b/projects/libs/flex-layout/grid/auto/auto.ts
@@ -70,6 +70,7 @@ export class GridAutoDirective extends BaseDirective2 {
   protected _inline = false;
 
   protected override DIRECTIVE_KEY = 'grid-auto';
+  protected override inputs = inputs;
 
   constructor(
     elementRef: ElementRef,

--- a/projects/libs/flex-layout/grid/column/column.ts
+++ b/projects/libs/flex-layout/grid/column/column.ts
@@ -45,6 +45,7 @@ const selector = `
 @Directive({ selector, inputs })
 export class GridColumnDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-column';
+  protected override inputs = inputs;
 
   constructor(
     elementRef: ElementRef,

--- a/projects/libs/flex-layout/grid/columns/columns.ts
+++ b/projects/libs/flex-layout/grid/columns/columns.ts
@@ -64,7 +64,8 @@ const selector = `
 @Directive({ selector, inputs })
 export class GridColumnsDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-columns';
-
+  protected override inputs = inputs;
+  
   @Input('gdInline')
   get inline(): boolean {
     return this._inline;

--- a/projects/libs/flex-layout/grid/gap/gap.ts
+++ b/projects/libs/flex-layout/grid/gap/gap.ts
@@ -48,9 +48,10 @@ const selector = `
   [gdGap.gt-xs], [gdGap.gt-sm], [gdGap.gt-md], [gdGap.gt-lg]
 `;
 
-@Directive()
+@Directive({ selector, inputs })
 export class GridGapDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-gap';
+  protected override inputs = inputs;
 
   @Input('gdInline')
   get inline(): boolean {

--- a/projects/libs/flex-layout/grid/grid-align/grid-align.ts
+++ b/projects/libs/flex-layout/grid/grid-align/grid-align.ts
@@ -44,6 +44,7 @@ const selector = `
 @Directive({ selector, inputs })
 export class GridAlignDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-align';
+  protected override inputs = inputs;
 
   constructor(
     elementRef: ElementRef,

--- a/projects/libs/flex-layout/grid/row/row.ts
+++ b/projects/libs/flex-layout/grid/row/row.ts
@@ -43,6 +43,7 @@ const selector = `
 @Directive({ selector, inputs })
 export class GridRowDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-row';
+  protected override inputs = inputs;
 
   constructor(
     elementRef: ElementRef,

--- a/projects/libs/flex-layout/grid/rows/rows.ts
+++ b/projects/libs/flex-layout/grid/rows/rows.ts
@@ -37,9 +37,35 @@ export class GridRowsStyleBuilder extends StyleBuilder {
   }
 }
 
-@Directive()
+
+const inputs = [
+  'gdRows',
+  'gdRows.xs',
+  'gdRows.sm',
+  'gdRows.md',
+  'gdRows.lg',
+  'gdRows.xl',
+  'gdRows.lt-sm',
+  'gdRows.lt-md',
+  'gdRows.lt-lg',
+  'gdRows.lt-xl',
+  'gdRows.gt-xs',
+  'gdRows.gt-sm',
+  'gdRows.gt-md',
+  'gdRows.gt-lg',
+];
+
+const selector = `
+  [gdRows],
+  [gdRows.xs], [gdRows.sm], [gdRows.md], [gdRows.lg], [gdRows.xl],
+  [gdRows.lt-sm], [gdRows.lt-md], [gdRows.lt-lg], [gdRows.lt-xl],
+  [gdRows.gt-xs], [gdRows.gt-sm], [gdRows.gt-md], [gdRows.gt-lg]
+`;
+
+@Directive({ selector, inputs })
 export class GridRowsDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-rows';
+  protected override inputs = inputs;
 
   @Input('gdInline')
   get inline(): boolean {
@@ -72,30 +98,6 @@ export class GridRowsDirective extends BaseDirective2 {
 
 const rowsCache: Map<string, StyleDefinition> = new Map();
 const rowsInlineCache: Map<string, StyleDefinition> = new Map();
-
-const inputs = [
-  'gdRows',
-  'gdRows.xs',
-  'gdRows.sm',
-  'gdRows.md',
-  'gdRows.lg',
-  'gdRows.xl',
-  'gdRows.lt-sm',
-  'gdRows.lt-md',
-  'gdRows.lt-lg',
-  'gdRows.lt-xl',
-  'gdRows.gt-xs',
-  'gdRows.gt-sm',
-  'gdRows.gt-md',
-  'gdRows.gt-lg',
-];
-
-const selector = `
-  [gdRows],
-  [gdRows.xs], [gdRows.sm], [gdRows.md], [gdRows.lg], [gdRows.xl],
-  [gdRows.lt-sm], [gdRows.lt-md], [gdRows.lt-lg], [gdRows.lt-xl],
-  [gdRows.gt-xs], [gdRows.gt-sm], [gdRows.gt-md], [gdRows.gt-lg]
-`;
 
 /**
  * 'grid-template-rows' CSS Grid styling directive


### PR DESCRIPTION
- Overrides `inputs` in the base classes
- Adds missing deprecation notice
- Adds missing selector/inputs