### PR TITLE
Fix missing overrides in 3 directives (those new ones without 'Default' prefix)

### DIFF
--- a/projects/libs/flex-layout/extended/class/class.ts
+++ b/projects/libs/flex-layout/extended/class/class.ts
@@ -38,6 +38,7 @@ const selector = `
 @Directive({ selector, inputs })
 export class ClassDirective extends BaseDirective2 implements DoCheck {
   protected override DIRECTIVE_KEY = 'ngClass';
+  protected override inputs = inputs;
 
   /**
    * Capture class assignments so we cache the default classes

--- a/projects/libs/flex-layout/extended/img-src/img-src.ts
+++ b/projects/libs/flex-layout/extended/img-src/img-src.ts
@@ -48,6 +48,7 @@ const selector = `
 @Directive({ selector, inputs })
 export class ImgSrcDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'img-src';
+  protected override inputs = inputs;
   protected defaultSrc = '';
 
   @Input('src')

--- a/projects/libs/flex-layout/extended/show-hide/show-hide.ts
+++ b/projects/libs/flex-layout/extended/show-hide/show-hide.ts
@@ -88,6 +88,7 @@ export class ShowHideDirective
   implements AfterViewInit, OnChanges
 {
   protected override DIRECTIVE_KEY = 'show-hide';
+  protected override inputs = inputs;
 
   /** Original DOM Element CSS display style */
   protected display = '';


### PR DESCRIPTION
Hi,

After migrating to version `v20` and switching from deprecated imports (`Default*Directive` -> `*Directive`) I've noticed that `fxShow/fxHide` were not working and discovered that `inputs` overrides were not implemented for them.
This PR fixes all missing occurrences that I've found 😊

@DuncanFaulkner 