### PR TITLE
fix(layout-gap): use direction-independent CSS properties for fxLayou…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * **etag:** removed etag ([22ba2d9](https://github.com/ngbracket/ngx-layout/commit/22ba2d90b521cdd3ec62eefb7d31992acf1858a3))
 * **flex-layout:** use aliased imports from primary entry point to secondary entry point ([#76](https://github.com/ngbracket/ngx-layout/issues/76)) ([021f1ae](https://github.com/ngbracket/ngx-layout/commit/021f1aed563d2b3488beb759675f2c92dc7d39bc))
+* **layout-gap:** use direction-independent (logical) CSS properties for `fxLayoutGap` so layouts are not broken under `direction: rtl` ([#95](https://github.com/ngbracket/ngx-layout/issues/95))
 * **package:** remove package lock file ([9f75640](https://github.com/ngbracket/ngx-layout/commit/9f75640221d012856f90cf4d92bbf3ed4dbfad1e))
 * **package:** update package json to match yarn lock for browser-sync-client ([ab0549a](https://github.com/ngbracket/ngx-layout/commit/ab0549a3d4fe1304212ae8909528b92fe647083b))
 * remove duplicate dependencies from package.json ([2812287](https://github.com/ngbracket/ngx-layout/commit/281228716d24a3c2fd6a90748f929a7e8a78d07a))

--- a/projects/libs/flex-layout/flex/layout-gap/layout-gap.spec.ts
+++ b/projects/libs/flex-layout/flex/layout-gap/layout-gap.spec.ts
@@ -119,7 +119,7 @@ describe('layout-gap directive', () => {
           `;
       createTestComponent(template);
       expectEl(queryFor(fixture, '[fxFlex]')[0]).not.toHaveStyle(
-        { 'margin-right': '13px;' },
+        { 'margin-inline-end': '13px;' },
         styler,
       );
     });
@@ -137,10 +137,10 @@ describe('layout-gap directive', () => {
 
       const nodes = queryFor(fixture, '[fxFlex]');
       expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '0px' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '0px' }, styler);
     });
 
     it('should add gap styles to all children except the 1st child w/ multiplier', () => {
@@ -156,10 +156,10 @@ describe('layout-gap directive', () => {
 
       const nodes = queryFor(fixture, '[fxFlex]');
       expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-right': '52px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-right': '52px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '52px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '0px' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '52px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '52px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '52px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '0px' }, styler);
     });
 
     it('should add gap styles to all children except the 1st child w/o unit', () => {
@@ -175,10 +175,10 @@ describe('layout-gap directive', () => {
 
       const nodes = queryFor(fixture, '[fxFlex]');
       expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '0px' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '0px' }, styler);
     });
 
     it('should add gap styles in proper order when order style is applied', () => {
@@ -194,10 +194,10 @@ describe('layout-gap directive', () => {
 
       const nodes = queryFor(fixture, '[fxFlex]');
       expect(nodes.length).toEqual(3);
-      expectEl(nodes[2]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-right': '0px' }, styler);
+      expectEl(nodes[2]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-inline-end': '0px' }, styler);
     });
 
     it('should add gap styles to dynamics rows EXCEPT first', () => {
@@ -212,11 +212,11 @@ describe('layout-gap directive', () => {
 
       const nodes = queryFor(fixture, '[fxFlex]');
       expect(nodes.length).toEqual(4);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[2]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[3]).not.toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[3]).not.toHaveStyle({ 'margin-right': '0px' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[2]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[3]).not.toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[3]).not.toHaveStyle({ 'margin-inline-end': '0px' }, styler);
     });
 
     it('should add update gap styles when row items are removed', waitForAsync(() => {
@@ -243,10 +243,10 @@ describe('layout-gap directive', () => {
         expect(nodes.length).toEqual(3);
 
         if (typeof MutationObserver !== 'undefined') {
-          expectEl(nodes[0]).toHaveStyle({ 'margin-right': '13px' }, styler);
-          expectEl(nodes[1]).toHaveStyle({ 'margin-right': '13px' }, styler);
+          expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+          expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
           expectEl(nodes[2]).not.toHaveStyle(
-            { 'margin-right': '13px' },
+            { 'margin-inline-end': '13px' },
             styler,
           );
         }
@@ -266,8 +266,8 @@ describe('layout-gap directive', () => {
       let nodes = queryFor(fixture, '[fxFlex]');
 
       expect(nodes.length).toEqual(4);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[3]).not.toHaveStyle({ 'margin-right': '13px' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[3]).not.toHaveStyle({ 'margin-inline-end': '13px' }, styler);
 
       fixture.componentInstance.rows = new Array(1);
       fixture.detectChanges();
@@ -281,7 +281,7 @@ describe('layout-gap directive', () => {
         expect(nodes.length).toEqual(1);
         if (typeof MutationObserver !== 'undefined') {
           expectEl(nodes[0]).not.toHaveStyle(
-            { 'margin-right': '13px' },
+            { 'margin-inline-end': '13px' },
             styler,
           );
         }
@@ -289,15 +289,15 @@ describe('layout-gap directive', () => {
     }));
 
     it('should apply margin-top for column layouts', () => {
-      verifyCorrectMargin('column', 'margin-bottom');
+      verifyCorrectMargin('column', 'margin-block-end');
     });
 
-    it('should apply margin-left for row-reverse layouts', () => {
-      verifyCorrectMargin('row-reverse', 'margin-left');
+    it('should apply margin-inline-start for row-reverse layouts', () => {
+      verifyCorrectMargin('row-reverse', 'margin-inline-start');
     });
 
-    it('should apply margin-top for column-reverse layouts', () => {
-      verifyCorrectMargin('column-reverse', 'margin-top');
+    it('should apply margin-block-start for column-reverse layouts', () => {
+      verifyCorrectMargin('column-reverse', 'margin-block-start');
     });
 
     it('should remove obsolete margin and apply valid margin for layout changes', () => {
@@ -315,24 +315,24 @@ describe('layout-gap directive', () => {
       fixture.detectChanges();
       let nodes = queryFor(fixture, 'span');
 
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-right': '8px' }, styler);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-bottom': '8px' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-inline-end': '8px' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-block-end': '8px' }, styler);
 
-      // layout = column-reverse, use margin-bottom
+      // layout = column-reverse, use margin-block-start
       instance.direction = 'column-reverse';
       fixture.detectChanges();
       nodes = queryFor(fixture, 'span');
 
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-right': '8px' }, styler);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-top': '8px' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-inline-end': '8px' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-block-start': '8px' }, styler);
 
-      // layout = row-reverse, use margin-right
+      // layout = row-reverse, use margin-inline-start
       instance.direction = 'row-reverse';
       fixture.detectChanges();
       nodes = queryFor(fixture, 'span');
 
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-bottom': '8px' }, styler);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-left': '8px' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-block-end': '8px' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-start': '8px' }, styler);
     });
 
     it('should recognize hidden elements when applying gaps', () => {
@@ -353,10 +353,10 @@ describe('layout-gap directive', () => {
       expect(nodes.length).toEqual(3);
       // TODO(CaerusKaru): Domino is unable to detect this style
       if (!isPlatformServer(platformId)) {
-        expectEl(nodes[0]).not.toHaveStyle({ 'margin-right': '0px' }, styler);
-        expectEl(nodes[0]).not.toHaveStyle({ 'margin-right': '16px' }, styler);
-        expectEl(nodes[1]).toHaveStyle({ 'margin-right': '16px' }, styler);
-        expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '16px' }, styler);
+        expectEl(nodes[0]).not.toHaveStyle({ 'margin-inline-end': '0px' }, styler);
+        expectEl(nodes[0]).not.toHaveStyle({ 'margin-inline-end': '16px' }, styler);
+        expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '16px' }, styler);
+        expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '16px' }, styler);
       }
     });
 
@@ -382,10 +382,10 @@ describe('layout-gap directive', () => {
       expect(nodes.length).toEqual(4);
       // TODO(CaerusKaru): Domino is unable to detect this style
       if (!isPlatformServer(platformId)) {
-        expectEl(nodes[0]).not.toHaveStyle({ 'margin-right': '16px' }, styler);
-        expectEl(nodes[1]).toHaveStyle({ 'margin-right': '16px' }, styler);
-        expectEl(nodes[2]).toHaveStyle({ 'margin-right': '16px' }, styler);
-        expectEl(nodes[3]).not.toHaveStyle({ 'margin-right': '16px' }, styler);
+        expectEl(nodes[0]).not.toHaveStyle({ 'margin-inline-end': '16px' }, styler);
+        expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '16px' }, styler);
+        expectEl(nodes[2]).toHaveStyle({ 'margin-inline-end': '16px' }, styler);
+        expectEl(nodes[3]).not.toHaveStyle({ 'margin-inline-end': '16px' }, styler);
       }
 
       fixture.componentInstance.gap = '8px';
@@ -397,10 +397,10 @@ describe('layout-gap directive', () => {
       expect(nodes.length).toEqual(4);
       // TODO(CaerusKaru): Domino is unable to detect this style
       if (!isPlatformServer(platformId)) {
-        expectEl(nodes[0]).not.toHaveStyle({ 'margin-bottom': '8px' }, styler);
-        expectEl(nodes[1]).toHaveStyle({ 'margin-bottom': '8px' }, styler);
-        expectEl(nodes[2]).toHaveStyle({ 'margin-bottom': '8px' }, styler);
-        expectEl(nodes[3]).not.toHaveStyle({ 'margin-bottom': '8px' }, styler);
+        expectEl(nodes[0]).not.toHaveStyle({ 'margin-block-end': '8px' }, styler);
+        expectEl(nodes[1]).toHaveStyle({ 'margin-block-end': '8px' }, styler);
+        expectEl(nodes[2]).toHaveStyle({ 'margin-block-end': '8px' }, styler);
+        expectEl(nodes[3]).not.toHaveStyle({ 'margin-block-end': '8px' }, styler);
       }
     });
   });
@@ -419,17 +419,17 @@ describe('layout-gap directive', () => {
 
       const nodes = queryFor(fixture, '[fxFlex]');
       expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '0px' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '0px' }, styler);
 
       mediaController.activate('md');
       fixture.detectChanges();
-      expectEl(nodes[0]).toHaveStyle({ 'margin-right': '24px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-right': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '0px' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '24px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '24px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '24px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '0px' }, styler);
     });
 
     it('should set gap without fallback', () => {
@@ -446,21 +446,21 @@ describe('layout-gap directive', () => {
       const nodes = queryFor(fixture, '[fxFlex]');
       expect(nodes.length).toEqual(3);
       mediaController.activate('sm');
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-right': '*' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-right': '*' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '*' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
+      expectEl(nodes[1]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
 
       mediaController.activate('md');
       fixture.detectChanges();
-      expectEl(nodes[0]).toHaveStyle({ 'margin-right': '24px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-right': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '0px' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '24px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '24px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '24px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '0px' }, styler);
 
       mediaController.activate('sm');
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-right': '*' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-right': '*' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '*' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
+      expectEl(nodes[1]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
     });
 
     it('should set gap with responsive layout change', () => {
@@ -476,15 +476,15 @@ describe('layout-gap directive', () => {
 
       const nodes = queryFor(fixture, '[fxFlex]');
       expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-right': '24px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-right': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '*' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '24px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '24px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
 
       mediaController.activate('xs');
       fixture.detectChanges();
-      expectEl(nodes[0]).toHaveStyle({ 'margin-bottom': '24px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-bottom': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-block-end': '24px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-block-end': '24px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
     });
 
     it('should remove gaps with responsive layout change', () => {
@@ -500,22 +500,22 @@ describe('layout-gap directive', () => {
 
       mediaController.activate('md');
       fixture.detectChanges();
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-bottom': '24px' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-bottom': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-block-end': '24px' }, styler);
+      expectEl(nodes[1]).not.toHaveStyle({ 'margin-block-end': '24px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
 
       mediaController.activate('xs');
       fixture.detectChanges();
       expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-bottom': '24px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-bottom': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-block-end': '24px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-block-end': '24px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
 
       mediaController.activate('md');
       fixture.detectChanges();
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-bottom': '24px' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-bottom': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-block-end': '24px' }, styler);
+      expectEl(nodes[1]).not.toHaveStyle({ 'margin-block-end': '24px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
     });
 
     it('should add gap styles in proper order when order style is applied on responsive layout change', () => {
@@ -532,15 +532,15 @@ describe('layout-gap directive', () => {
       mediaController.activate('md');
       fixture.detectChanges();
       expect(nodes.length).toEqual(3);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
+      expectEl(nodes[1]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
 
       mediaController.activate('xs');
       fixture.detectChanges();
-      expectEl(nodes[2]).toHaveStyle({ 'margin-bottom': '20px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-bottom': '20px' }, styler);
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-bottom': '*' }, styler);
+      expectEl(nodes[2]).toHaveStyle({ 'margin-block-end': '20px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-block-end': '20px' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
     });
 
     it('should work with dynamic fxHide', () => {
@@ -555,15 +555,15 @@ describe('layout-gap directive', () => {
 
       const nodes = queryFor(fixture, '[fxFlex]');
       expect(nodes.length).toEqual(2);
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-right': '*' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-right': '*' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
+      expectEl(nodes[1]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
 
       const instance = fixture.componentInstance;
       instance.shouldHide = false;
       fixture.detectChanges();
 
-      expectEl(nodes[0]).toHaveStyle({ 'margin-right': '10px' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-right': '*' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '10px' }, styler);
+      expectEl(nodes[1]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
     });
 
     it('should work with responsive fxHide', () => {
@@ -579,38 +579,41 @@ describe('layout-gap directive', () => {
 
       const nodes = queryFor(fixture, '[fxFlex]');
       expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '*' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
 
       mediaController.activate('sm');
       fixture.detectChanges();
-      expectEl(nodes[0]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-right': '*' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '*' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[1]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
 
       mediaController.activate('lg');
       fixture.detectChanges();
-      expectEl(nodes[0]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-right': '13px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-right': '*' }, styler);
+      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
     });
   });
 
   describe('rtl support', () => {
-    it('uses margin-left when document body has rtl dir', () => {
+    // Logical properties (margin-inline-end) are direction-independent: the
+    // directive emits the same property regardless of `dir`, and the browser
+    // resolves it against the writing direction. See issue #95.
+    it('uses margin-inline-end when document body has rtl dir', () => {
       fakeDocument.body.dir = 'rtl';
-      verifyCorrectMargin('row', 'margin-left');
+      verifyCorrectMargin('row', 'margin-inline-end');
     });
 
-    it('uses margin-left when documentElement has rtl dir', () => {
+    it('uses margin-inline-end when documentElement has rtl dir', () => {
       fakeDocument.documentElement.dir = 'rtl';
-      verifyCorrectMargin('row', 'margin-left');
+      verifyCorrectMargin('row', 'margin-inline-end');
     });
 
-    it('still uses margin-bottom in column layout when body has rtl dir', () => {
+    it('still uses margin-block-end in column layout when body has rtl dir', () => {
       fakeDocument.body.dir = 'rtl';
-      verifyCorrectMargin('column', 'margin-bottom');
+      verifyCorrectMargin('column', 'margin-block-end');
     });
   });
 
@@ -627,8 +630,14 @@ describe('layout-gap directive', () => {
       fixture.detectChanges();
 
       const nodes = queryFor(fixture, '[fxFlex]');
-      const expectedMargin = { margin: '0px -13px -13px 0px' };
-      const expectedPadding = { padding: '0px 13px 13px 0px' };
+      const expectedMargin = {
+        'margin-inline': '0px -13px',
+        'margin-block': '0px -13px',
+      };
+      const expectedPadding = {
+        'padding-inline': '0px 13px',
+        'padding-block': '0px 13px',
+      };
       expect(nodes.length).toEqual(3);
       expectEl(nodes[0]).toHaveStyle(expectedPadding, styler);
       expectEl(nodes[1]).toHaveStyle(expectedPadding, styler);
@@ -648,8 +657,14 @@ describe('layout-gap directive', () => {
       fixture.detectChanges();
 
       const nodes = queryFor(fixture, '[fxFlex]');
-      const expectedMargin = { margin: '0px -52px -52px 0px' };
-      const expectedPadding = { padding: '0px 52px 52px 0px' };
+      const expectedMargin = {
+        'margin-inline': '0px -52px',
+        'margin-block': '0px -52px',
+      };
+      const expectedPadding = {
+        'padding-inline': '0px 52px',
+        'padding-block': '0px 52px',
+      };
       expect(nodes.length).toEqual(3);
       expectEl(nodes[0]).toHaveStyle(expectedPadding, styler);
       expectEl(nodes[1]).toHaveStyle(expectedPadding, styler);
@@ -669,8 +684,14 @@ describe('layout-gap directive', () => {
       fixture.detectChanges();
 
       const nodes = queryFor(fixture, '[fxFlex]');
-      const expectedMargin = { margin: '0px -13px -12px 0px' };
-      const expectedPadding = { padding: '0px 13px 12px 0px' };
+      const expectedMargin = {
+        'margin-inline': '0px -13px',
+        'margin-block': '0px -12px',
+      };
+      const expectedPadding = {
+        'padding-inline': '0px 13px',
+        'padding-block': '0px 12px',
+      };
       expect(nodes.length).toEqual(3);
       expectEl(nodes[0]).toHaveStyle(expectedPadding, styler);
       expectEl(nodes[1]).toHaveStyle(expectedPadding, styler);
@@ -692,23 +713,29 @@ describe('layout-gap directive', () => {
       const nodes = queryFor(fixture, '[fxFlex]');
       expect(nodes.length).toEqual(3);
       mediaController.activate('sm');
-      expectEl(nodes[0]).not.toHaveStyle({ padding: '*' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ padding: '*' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ padding: '*' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'padding-inline': '*' }, styler);
+      expectEl(nodes[1]).not.toHaveStyle({ 'padding-inline': '*' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'padding-inline': '*' }, styler);
 
       mediaController.activate('md');
       fixture.detectChanges();
-      expectEl(nodes[0]).toHaveStyle({ padding: '0px 24px 24px 0px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ padding: '0px 24px 24px 0px' }, styler);
-      expectEl(nodes[2]).toHaveStyle({ padding: '0px 24px 24px 0px' }, styler);
+      const expectedPadding = {
+        'padding-inline': '0px 24px',
+        'padding-block': '0px 24px',
+      };
+      expectEl(nodes[0]).toHaveStyle(expectedPadding, styler);
+      expectEl(nodes[1]).toHaveStyle(expectedPadding, styler);
+      expectEl(nodes[2]).toHaveStyle(expectedPadding, styler);
 
       mediaController.activate('sm');
-      expectEl(nodes[0]).not.toHaveStyle({ padding: '*' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ padding: '*' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ padding: '*' }, styler);
+      expectEl(nodes[0]).not.toHaveStyle({ 'padding-inline': '*' }, styler);
+      expectEl(nodes[1]).not.toHaveStyle({ 'padding-inline': '*' }, styler);
+      expectEl(nodes[2]).not.toHaveStyle({ 'padding-inline': '*' }, styler);
     });
 
     it('should add gap styles correctly for rtl', () => {
+      // Logical properties are direction-independent, so the emitted styles are
+      // identical to the ltr case; the browser resolves them against `rtl`.
       fakeDocument.body.dir = 'rtl';
       const template = `
         <div fxLayoutGap='13px grid'>
@@ -721,8 +748,14 @@ describe('layout-gap directive', () => {
       fixture.detectChanges();
 
       const nodes = queryFor(fixture, '[fxFlex]');
-      const expectedMargin = { margin: '0px 0px -13px -13px' };
-      const expectedPadding = { padding: '0px 0px 13px 13px' };
+      const expectedMargin = {
+        'margin-inline': '0px -13px',
+        'margin-block': '0px -13px',
+      };
+      const expectedPadding = {
+        'padding-inline': '0px 13px',
+        'padding-block': '0px 13px',
+      };
       expect(nodes.length).toEqual(3);
       expectEl(nodes[0]).toHaveStyle(expectedPadding, styler);
       expectEl(nodes[1]).toHaveStyle(expectedPadding, styler);

--- a/projects/libs/flex-layout/flex/layout-gap/layout-gap.ts
+++ b/projects/libs/flex-layout/flex/layout-gap/layout-gap.ts
@@ -1,5 +1,4 @@
 /* eslint-disable prefer-const */
-import { Directionality } from '@angular/cdk/bidi';
 import {
   AfterContentInit,
   Directive,
@@ -25,16 +24,15 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 export interface LayoutGapParent {
-  directionality: string;
   items: HTMLElement[];
   layout: string;
 }
 
 const CLEAR_MARGIN_CSS = {
-  'margin-left': null,
-  'margin-right': null,
-  'margin-top': null,
-  'margin-bottom': null,
+  'margin-inline-start': null,
+  'margin-inline-end': null,
+  'margin-block-start': null,
+  'margin-block-end': null,
 };
 
 @Injectable({ providedIn: 'root' })
@@ -52,7 +50,7 @@ export class LayoutGapStyleBuilder extends StyleBuilder {
       gapValue = multiply(gapValue, this._config.multiplier);
 
       // Add the margin to the host element
-      return buildGridMargin(gapValue, parent.directionality);
+      return buildGridMargin(gapValue);
     } else {
       return {};
     }
@@ -68,7 +66,7 @@ export class LayoutGapStyleBuilder extends StyleBuilder {
       gapValue = gapValue.slice(0, gapValue.indexOf(GRID_SPECIFIER));
       gapValue = multiply(gapValue, this._config.multiplier);
       // For each `element` children, set the padding
-      const paddingStyles = buildGridPadding(gapValue, parent.directionality);
+      const paddingStyles = buildGridPadding(gapValue);
       this._styler.applyStyleToElements(paddingStyles, parent.items);
     } else {
       gapValue = multiply(gapValue, this._config.multiplier);
@@ -143,16 +141,12 @@ export class LayoutGapDirective
   constructor(
     elRef: ElementRef,
     protected zone: NgZone,
-    protected directionality: Directionality,
     protected styleUtils: StyleUtils,
     styleBuilder: LayoutGapStyleBuilder,
     marshal: MediaMarshaller,
   ) {
     super(elRef, styleBuilder, styleUtils, marshal);
-    const extraTriggers = [
-      this.directionality.change,
-      this.observerSubject.asObservable(),
-    ];
+    const extraTriggers = [this.observerSubject.asObservable()];
     this.init(extraTriggers);
     this.marshal
       .trackValue(this.nativeElement, 'layout')
@@ -220,38 +214,30 @@ export class LayoutGapDirective
       });
 
     if (items.length > 0) {
-      const directionality = this.directionality.value;
-      const layout = this.layout;
-      if (layout === 'row' && directionality === 'rtl') {
-        this.styleCache = layoutGapCacheRowRtl;
-      } else if (layout === 'row' && directionality !== 'rtl') {
-        this.styleCache = layoutGapCacheRowLtr;
-      } else if (layout === 'column' && directionality === 'rtl') {
-        this.styleCache = layoutGapCacheColumnRtl;
-      } else if (layout === 'column' && directionality !== 'rtl') {
-        this.styleCache = layoutGapCacheColumnLtr;
-      }
-      this.addStyles(value, { directionality, items, layout });
+      this.addStyles(value, { items, layout: this.layout });
     }
   }
 
   /** We need to override clearStyles because in most cases mru isn't populated */
   protected override clearStyles() {
     const gridMode = Object.keys(this.mru).length > 0;
-    const childrenStyle = gridMode
-      ? 'padding'
-      : getMarginType(this.directionality.value, this.layout);
 
     // If there are styles on the parent remove them
     if (gridMode) {
       super.clearStyles();
-    }
 
-    // Then remove the children styles too
-    this.styleUtils.applyStyleToElements(
-      { [childrenStyle]: '' },
-      this.childrenNodes,
-    );
+      // Then remove the children grid padding too
+      this.styleUtils.applyStyleToElements(
+        { 'padding-inline': '', 'padding-block': '' },
+        this.childrenNodes,
+      );
+    } else {
+      // Remove the children gap margin
+      this.styleUtils.applyStyleToElements(
+        { [getMarginType(this.layout)]: '' },
+        this.childrenNodes,
+      );
+    }
   }
 
   /** Determine if an element will show or hide based on current activation */
@@ -297,72 +283,53 @@ export class DefaultLayoutGapDirective extends LayoutGapDirective {
   protected override inputs = inputs;
 }
 
-const layoutGapCacheRowRtl: Map<string, StyleDefinition> = new Map();
-const layoutGapCacheColumnRtl: Map<string, StyleDefinition> = new Map();
-const layoutGapCacheRowLtr: Map<string, StyleDefinition> = new Map();
-const layoutGapCacheColumnLtr: Map<string, StyleDefinition> = new Map();
-
 const GRID_SPECIFIER = ' grid';
 
-function buildGridPadding(
-  value: string,
-  directionality: string,
-): StyleDefinition {
+function buildGridPadding(value: string): StyleDefinition {
   const [between, below] = value.split(' ');
   const bottom = below ?? between;
-  let paddingRight = '0px',
-    paddingBottom = bottom,
-    paddingLeft = '0px';
 
-  if (directionality === 'rtl') {
-    paddingLeft = between;
-  } else {
-    paddingRight = between;
-  }
-
-  return { padding: `0px ${paddingRight} ${paddingBottom} ${paddingLeft}` };
+  // Use logical properties so the gap follows the writing direction
+  // (e.g. `direction: rtl`) without inspecting the directionality.
+  return {
+    'padding-inline': `0px ${between}`,
+    'padding-block': `0px ${bottom}`,
+  };
 }
 
-function buildGridMargin(
-  value: string,
-  directionality: string,
-): StyleDefinition {
+function buildGridMargin(value: string): StyleDefinition {
   const [between, below] = value.split(' ');
   const bottom = below ?? between;
   const minus = (str: string) => `-${str}`;
-  let marginRight = '0px',
-    marginBottom = minus(bottom),
-    marginLeft = '0px';
 
-  if (directionality === 'rtl') {
-    marginLeft = minus(between);
-  } else {
-    marginRight = minus(between);
-  }
-
-  return { margin: `0px ${marginRight} ${marginBottom} ${marginLeft}` };
+  // Use logical properties so the gap follows the writing direction
+  // (e.g. `direction: rtl`) without inspecting the directionality.
+  return {
+    'margin-inline': `0px ${minus(between)}`,
+    'margin-block': `0px ${minus(bottom)}`,
+  };
 }
 
-function getMarginType(directionality: string, layout: string) {
+function getMarginType(layout: string) {
   switch (layout) {
     case 'column':
-      return 'margin-bottom';
+      return 'margin-block-end';
     case 'column-reverse':
-      return 'margin-top';
+      return 'margin-block-start';
     case 'row':
-      return directionality === 'rtl' ? 'margin-left' : 'margin-right';
+      return 'margin-inline-end';
     case 'row-reverse':
-      return directionality === 'rtl' ? 'margin-right' : 'margin-left';
+      return 'margin-inline-start';
     default:
-      return directionality === 'rtl' ? 'margin-left' : 'margin-right';
+      return 'margin-inline-end';
   }
 }
 
 function buildGapCSS(
   gapValue: string,
-  parent: { directionality: string; layout: string },
+  parent: { layout: string },
 ): StyleDefinition {
-  const key = getMarginType(parent.directionality, parent.layout);
+  const key = getMarginType(parent.layout);
   const margins: { [key: string]: string | null } = { ...CLEAR_MARGIN_CSS };
   margins[key] = gapValue;
   return margins;


### PR DESCRIPTION
## Summary

Fixes #95. `fxLayoutGap` emitted **physical** margin properties (`margin-right`/`margin-left`) and chose between them by reading the CDK `Directionality` (the `dir` attribute). That broke layouts when the writing direction was set via CSS `direction: rtl` (the reporter's case), and required LTR/RTL branching throughout the directive.

This switches `fxLayoutGap` to **direction-independent logical properties**, which the browser resolves against the writing direction automatically — fixing the RTL bug and removing the manual direction handling entirely.

## Changes

| Layout | Before (physical) | After (logical) |
|---|---|---|
| `row` | `margin-right` / `margin-left` | `margin-inline-end` |
| `row-reverse` | `margin-left` / `margin-right` | `margin-inline-start` |
| `column` | `margin-bottom` | `margin-block-end` |
| `column-reverse` | `margin-top` | `margin-block-start` |
| grid (host) | `margin` shorthand | `margin-inline` / `margin-block` |
| grid (children) | `padding` shorthand | `padding-inline` / `padding-block` |

### Dead code removed

Because the emitted CSS no longer depends on direction:
- Removed the `Directionality` injection and its `change` trigger.
- Removed the four direction-keyed style caches (`layoutGapCacheRow/Column × Rtl/Ltr`) and the cache-selection block in `updateWithValue` — the inherited single `styleCache` now suffices, since the cached `buildStyles` output is direction- and layout-independent.
- Removed the now-unused `directionality` field from `LayoutGapParent`.

## Testing

- Updated `layout-gap.spec.ts` to assert the logical properties (the RTL specs now verify the directive emits the *same* property regardless of `dir`, leaving the flip to the browser).
- Confirmed jsdom round-trips the logical properties.
- **Full library suite passes: 478/478.**

Closes #95