### PR TITLE
fix(core): guard against undefined element.style during style flush (#57)

### DIFF
--- a/projects/libs/flex-layout/core/style-utils/style-utils.spec.ts
+++ b/projects/libs/flex-layout/core/style-utils/style-utils.spec.ts
@@ -81,6 +81,19 @@ describe('styler', () => {
         expectNativeEl(fixture).toHaveCSS({ display: 'table' }, styler);
       }
     });
+
+    it('should not throw when the target element has no style property', () => {
+      // Reproduces issue #57: a detached/destroyed element can still be flushed
+      // during a media (resize) update, where `element.style` is undefined.
+      componentWithTemplate(`<div></div>`);
+
+      if (!isPlatformServer(platformId)) {
+        const fakeEl = { style: undefined } as unknown as HTMLElement;
+        expect(() =>
+          styler.applyStyleToElement(fakeEl, { display: 'flex' }),
+        ).not.toThrow();
+      }
+    });
   });
 });
 

--- a/projects/libs/flex-layout/core/style-utils/style-utils.ts
+++ b/projects/libs/flex-layout/core/style-utils/style-utils.ts
@@ -140,9 +140,15 @@ export class StyleUtils {
             isPlatformBrowser(this._platformId) ||
             !this._serverModuleLoaded
           ) {
-            isPlatformBrowser(this._platformId)
-              ? element.style.setProperty(key, value)
-              : setServerStyle(element, key, value);
+            if (isPlatformBrowser(this._platformId)) {
+              // The element may have been detached/destroyed between a resize
+              // event firing and this style flush (e.g. on window resize), in
+              // which case it is no longer a styleable HTMLElement. Skip it
+              // rather than throwing and aborting the whole update pass.
+              element?.style?.setProperty(key, value);
+            } else {
+              setServerStyle(element, key, value);
+            }
           } else {
             this._serverStylesheet.addStyleToElement(element, key, value);
           }


### PR DESCRIPTION
## Summary

Fixes #57 — `TypeError: Cannot read properties of undefined (reading 'setProperty')` thrown from `ngx-layout` core, typically on window resize.

## Root cause

The crash originates in `StyleUtils._applyMultiValueStyleToElement`:

```ts
element.style.setProperty(key, value); // element.style is undefined
```

The call chain is `MediaMarshaller.updateStyles()` → `updateElement` → directive `updateWithValue` → `applyStyleToElement`, which runs on every breakpoint/media change (i.e. window resize).

The error message is `reading 'setProperty'` (not `reading 'style'`), so `element` is truthy but **`element.style` is `undefined`** — the tracked node is no longer a styleable `HTMLElement` at flush time. `MediaMarshaller.elementMap` is a strong `Map`, so an element released between the resize event firing and the style flush can still be iterated and flushed.

Because the throw aborted the whole `forEach` pass, a single stale element also broke styling for every remaining element in that update.

## Fix

Guard the browser `setProperty` call with optional chaining so a non-styleable element is skipped instead of crashing the update pass:

```ts
element?.style?.setProperty(key, value);
```

The server path (`setServerStyle`, attribute-based, no `.style`) is intentionally left untouched.

## Test

Added a regression test in `style-utils.spec.ts` asserting that `applyStyleToElement` does not throw when the target element's `.style` is `undefined` (simulating the detached-node case).

## Verification

- `ng test @ngbracket/ngx-layout` — **479 tests pass** (incl. new regression test)
- `ng build @ngbracket/ngx-layout` — builds clean, no type errors

## Follow-up (not in this PR)

A deeper fix would change `MediaMarshaller.elementMap` from a strong `Map` to a `WeakMap` (or guarantee `releaseElement` always runs) to avoid retaining/flushing dead elements at all. That's a larger, riskier change to core data structures and isn't required to resolve this crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)