### PR TITLE
feat(layout-gap): use CSS `gap` instead of child margins (#43)

### DIFF
--- a/projects/apps/docs/documentation/docs/fx-flex/fxLayoutGap-API.md
+++ b/projects/apps/docs/documentation/docs/fx-flex/fxLayoutGap-API.md
@@ -4,14 +4,20 @@ sidebar_position: 210
 
 # FxLayoutGap
 
-The [**fxLayoutGap** directive](https://github.com/ngbracket/ngx-layout/blob/main/src/lib/flex/layout-gap/layout-gap.ts#L38)
-should be used on to specify margin gaps on children within a flexbox container (e.g. nested within a fxLayout container).
+The [**fxLayoutGap** directive](https://github.com/ngbracket/ngx-layout/blob/main/src/lib/flex/layout-gap/layout-gap.ts)
+specifies the spacing between children within a flexbox container (e.g. nested within a fxLayout container).
 
-- `margin-right` used when the parent container `flex-direction` == "row"
-- `margin-bottom` used when the parent container `flex-direction` == "column"
+It applies the native CSS [`gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) property to the
+container itself, so the spacing is added _between_ items along the layout axis **and between wrapped rows/columns**.
 
-> Note that the last child item will **NOT** have a margin gap specified; only the inside gaps are specified. Additionally,
-> `fxLayoutGap` does not respond to reveresed flow directions: `column-reverse` or `row-reverse` are used.
+- A single value (e.g. `fxLayoutGap="20px"`) sets both the row and column gap.
+- Two values (e.g. `fxLayoutGap="10px 20px"`) map to the CSS `gap` shorthand: `<row-gap> <column-gap>`.
+- The gap is direction-independent: it behaves identically for `row`/`column`, reversed flows, and `rtl`.
+
+> **Breaking change (v22):** `fxLayoutGap` now uses CSS `gap` instead of applying `margin` to each child.
+> The element must be a flex container (apply `fxLayout`) for the gap to take effect. The legacy `" grid"`
+> suffix (e.g. `fxLayoutGap="10px grid"`) is still accepted but is now equivalent to a plain gap, since
+> `gap` already spaces wrapped rows correctly.
 
 ## Examples:
 
@@ -65,8 +71,12 @@ should be used on to specify margin gaps on children within a flexbox container 
 
 ### Using fxLayoutGap with **Wrap**
 
-When using `wrap` with `fxLayout` to wrap rows or columns, developers should account for the gap sizes when specifying
-the child item sizes (using fxFlex).
+Because `fxLayoutGap` now uses the CSS `gap` property, spacing is automatically applied **between wrapped rows and
+columns** as well as between items — without the extra leading-margin artifacts the previous margin-based
+implementation produced on the last/short row.
+
+When sizing wrapped children with `fxFlex`, still account for the gap so items fit per row, e.g.
+`fxFlex="calc(50% - 25px)"`.
 
 #### Issue: Rendered Layout without gap considerations:
 

--- a/projects/apps/updated-demo/src/app/pages/layout/gap/gap.component.ts
+++ b/projects/apps/updated-demo/src/app/pages/layout/gap/gap.component.ts
@@ -29,29 +29,29 @@ const DIRECTIONS = ['row', 'row-reverse', 'column', 'column-reverse'];
         <div
           fxFlexFill
           [fxLayout]="direction + ' wrap'"
-          fxLayoutGap="10px 5px grid"
+          fxLayoutGap="10px"
           style="cursor: pointer;"
           (click)="toggleDirection()"
         >
-          <div fxFlex="25">
+          <div fxFlex="calc(25% - 7.5px)">
             <div class="one" fxFlexFill fxLayoutAlign="center center">A</div>
           </div>
-          <div fxFlex="25">
+          <div fxFlex="calc(25% - 7.5px)">
             <div class="two" fxFlexFill fxLayoutAlign="center center">B</div>
           </div>
-          <div fxFlex="25">
+          <div fxFlex="calc(25% - 7.5px)">
             <div class="three" fxFlexFill fxLayoutAlign="center center">C</div>
           </div>
-          <div fxFlex="25">
+          <div fxFlex="calc(25% - 7.5px)">
             <div class="four" fxFlexFill fxLayoutAlign="center center">D</div>
           </div>
-          <div fxFlex="25">
+          <div fxFlex="calc(25% - 7.5px)">
             <div class="five" fxFlexFill fxLayoutAlign="center center">E</div>
           </div>
-          <div fxFlex="25">
+          <div fxFlex="calc(25% - 7.5px)">
             <div class="six" fxFlexFill fxLayoutAlign="center center">F</div>
           </div>
-          <div fxFlex="25">
+          <div fxFlex="calc(25% - 7.5px)">
             <div class="seven" fxFlexFill fxLayoutAlign="center center">G</div>
           </div>
         </div>

--- a/projects/libs/flex-layout/flex/layout-gap/layout-gap.spec.ts
+++ b/projects/libs/flex-layout/flex/layout-gap/layout-gap.spec.ts
@@ -8,33 +8,24 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import { DIR_DOCUMENT } from '@angular/cdk/bidi';
-import { CommonModule, isPlatformServer } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   Component,
   Injectable,
   OnInit,
   PLATFORM_ID,
-  ChangeDetectionStrategy,
 } from '@angular/core';
-import {
-  ComponentFixture,
-  inject,
-  TestBed,
-  waitForAsync,
-} from '@angular/core/testing';
+import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { FlexLayoutModule } from '@ngbracket/ngx-layout';
 import {
   DefaultFlexDirective,
-  DefaultFlexOrderDirective,
   DefaultLayoutDirective,
   DefaultLayoutGapDirective,
 } from '@ngbracket/ngx-layout/flex';
-import { DefaultShowHideDirective } from '@ngbracket/ngx-layout/extended';
 import {
-  expectEl,
   expectNativeEl,
   makeCreateTestComponent,
-  queryFor,
 } from '@ngbracket/ngx-layout/_private-utils/testing';
 import {
   ɵMatchMedia as MatchMedia,
@@ -98,630 +89,93 @@ describe('layout-gap directive', () => {
     });
   });
 
-  function verifyCorrectMargin(layout: string, marginKey: string) {
-    const margin = '8px';
+  /**
+   * `fxLayoutGap` applies the native CSS `gap` property to the flex container
+   * itself, so spacing is added both within a row/column and between wrapped
+   * rows. The gap is direction-independent (it works the same for row/column
+   * and for ltr/rtl).
+   */
+  function verifyContainerGap(layout: string, gap: string) {
     const template = `
-            <div fxLayout='${layout}' fxLayoutGap='${margin}'>
+            <div fxLayout='${layout}' fxLayoutGap='${gap}'>
                 <span></span>
                 <span></span>
             </div>
         `;
-
     createTestComponent(template);
-    fixture.detectChanges();
-
-    const nodes = queryFor(fixture, 'span');
-    const styles = { [marginKey]: margin };
-
-    expectEl(nodes[0]).toHaveStyle(styles, styler);
-    expectEl(nodes[1]).not.toHaveStyle(styles, styler);
+    expectNativeEl(fixture).toHaveStyle({ gap }, styler);
   }
 
   describe('with static features', () => {
-    it('should not add gap styles for a single child', () => {
+    it('should set the gap on the container', () => {
       const template = `
-              <div fxLayoutAlign='center center' fxLayoutGap='13px'>
-                  <div fxFlex></div>
-              </div>
-          `;
-      createTestComponent(template);
-      expectEl(queryFor(fixture, '[fxFlex]')[0]).not.toHaveStyle(
-        { 'margin-inline-end': '13px;' },
-        styler,
-      );
-    });
-
-    it('should add gap styles to all children except the 1st child', () => {
-      const template = `
-              <div fxLayoutAlign='center center' fxLayoutGap='13px'>
+              <div fxLayout='row' fxLayoutGap='13px'>
                   <div fxFlex></div>
                   <div fxFlex></div>
                   <div fxFlex></div>
               </div>
           `;
       createTestComponent(template);
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-      expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle(
-        { 'margin-inline-end': '13px' },
-        styler,
-      );
-      expectEl(nodes[2]).not.toHaveStyle(
-        { 'margin-inline-end': '0px' },
-        styler,
-      );
+      expectNativeEl(fixture).toHaveStyle({ gap: '13px' }, styler);
     });
 
-    it('should add gap styles to all children except the 1st child w/ multiplier', () => {
+    it('should set the gap on the container even with a single child', () => {
       const template = `
-              <div fxLayoutAlign='center center' fxLayoutGap='13x'>
+              <div fxLayout='row' fxLayoutGap='13px'>
                   <div fxFlex></div>
+              </div>
+          `;
+      createTestComponent(template);
+      expectNativeEl(fixture).toHaveStyle({ gap: '13px' }, styler);
+    });
+
+    it('should apply the multiplier to the gap value', () => {
+      const template = `
+              <div fxLayout='row' fxLayoutGap='13x'>
                   <div fxFlex></div>
                   <div fxFlex></div>
               </div>
           `;
       createTestComponent(template);
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-      expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '52px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '52px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle(
-        { 'margin-inline-end': '52px' },
-        styler,
-      );
-      expectEl(nodes[2]).not.toHaveStyle(
-        { 'margin-inline-end': '0px' },
-        styler,
-      );
+      expectNativeEl(fixture).toHaveStyle({ gap: '52px' }, styler);
     });
 
-    it('should add gap styles to all children except the 1st child w/o unit', () => {
+    it('should add the default unit when the gap value has no unit', () => {
       const template = `
-              <div fxLayoutAlign='center center' fxLayoutGap='13'>
-                  <div fxFlex></div>
+              <div fxLayout='row' fxLayoutGap='13'>
                   <div fxFlex></div>
                   <div fxFlex></div>
               </div>
           `;
       createTestComponent(template);
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-      expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle(
-        { 'margin-inline-end': '13px' },
-        styler,
-      );
-      expectEl(nodes[2]).not.toHaveStyle(
-        { 'margin-inline-end': '0px' },
-        styler,
-      );
+      expectNativeEl(fixture).toHaveStyle({ gap: '13px' }, styler);
     });
 
-    it('should add gap styles in proper order when order style is applied', () => {
+    it('should support a two-value (row/column) gap', () => {
       const template = `
-        <div fxLayoutAlign='center center' fxLayoutGap='13px'>
-          <div fxFlex fxFlexOrder="3"></div>
-          <div fxFlex fxFlexOrder="2"></div>
-          <div fxFlex fxFlexOrder="1"></div>
-        </div>
-      `;
-      createTestComponent(template);
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-      expect(nodes.length).toEqual(3);
-      expectEl(nodes[2]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[0]).not.toHaveStyle(
-        { 'margin-inline-end': '13px' },
-        styler,
-      );
-      expectEl(nodes[0]).not.toHaveStyle(
-        { 'margin-inline-end': '0px' },
-        styler,
-      );
-    });
-
-    it('should add gap styles to dynamics rows EXCEPT first', () => {
-      const template = `
-              <div fxLayoutAlign='center center' fxLayoutGap='13px'>
-                  <div fxFlex *ngFor='let row of rows'></div>
+              <div fxLayout='row wrap' fxLayoutGap='13px 24px'>
+                  <div fxFlex></div>
+                  <div fxFlex></div>
               </div>
           `;
       createTestComponent(template);
-      fixture.componentInstance.direction = 'row';
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-      expect(nodes.length).toEqual(4);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[2]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[3]).not.toHaveStyle(
-        { 'margin-inline-end': '13px' },
-        styler,
-      );
-      expectEl(nodes[3]).not.toHaveStyle(
-        { 'margin-inline-end': '0px' },
-        styler,
-      );
+      expectNativeEl(fixture).toHaveStyle({ gap: '13px 24px' }, styler);
     });
 
-    it('should add update gap styles when row items are removed', waitForAsync(() => {
-      const template = `
-              <div fxLayoutAlign='center center' fxLayoutGap='13px'>
-                  <div fxFlex *ngFor='let row of rows'></div>
-              </div>
-          `;
-      createTestComponent(template);
-      fixture.componentInstance.direction = 'row';
-      fixture.detectChanges();
-
-      let nodes = queryFor(fixture, '[fxFlex]');
-      expect(nodes.length).toEqual(4);
-
-      fixture.componentInstance.rows = new Array(3);
-      fixture.detectChanges();
-
-      setTimeout(() => {
-        // Since the layoutGap directive detects the *ngFor changes by using a MutationObserver, the
-        // browser will take up some time, to actually announce the changes to the directive.
-        // (Kudos to @DevVersion)
-        nodes = queryFor(fixture, '[fxFlex]');
-        expect(nodes.length).toEqual(3);
-
-        if (typeof MutationObserver !== 'undefined') {
-          expectEl(nodes[0]).toHaveStyle(
-            { 'margin-inline-end': '13px' },
-            styler,
-          );
-          expectEl(nodes[1]).toHaveStyle(
-            { 'margin-inline-end': '13px' },
-            styler,
-          );
-          expectEl(nodes[2]).not.toHaveStyle(
-            { 'margin-inline-end': '13px' },
-            styler,
-          );
-        }
-      });
-    }));
-
-    it('should add update gap styles when only 1 row is remaining', waitForAsync(() => {
-      const template = `
-              <div fxLayoutAlign='center center' fxLayoutGap='13px'>
-                  <div fxFlex *ngFor='let row of rows'></div>
-              </div>
-          `;
-      createTestComponent(template);
-      fixture.componentInstance.direction = 'row';
-      fixture.detectChanges();
-
-      let nodes = queryFor(fixture, '[fxFlex]');
-
-      expect(nodes.length).toEqual(4);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[3]).not.toHaveStyle(
-        { 'margin-inline-end': '13px' },
-        styler,
-      );
-
-      fixture.componentInstance.rows = new Array(1);
-      fixture.detectChanges();
-
-      setTimeout(() => {
-        // Since the layoutGap directive detects the *ngFor changes by using a MutationObserver, the
-        // browser will take up some time, to actually announce the changes to the directive.
-        // (Kudos to @DevVersion)
-        nodes = queryFor(fixture, '[fxFlex]');
-
-        expect(nodes.length).toEqual(1);
-        if (typeof MutationObserver !== 'undefined') {
-          expectEl(nodes[0]).not.toHaveStyle(
-            { 'margin-inline-end': '13px' },
-            styler,
-          );
-        }
-      });
-    }));
-
-    it('should apply margin-top for column layouts', () => {
-      verifyCorrectMargin('column', 'margin-block-end');
+    it('should set the gap for a row layout', () => {
+      verifyContainerGap('row', '8px');
     });
 
-    it('should apply margin-inline-start for row-reverse layouts', () => {
-      verifyCorrectMargin('row-reverse', 'margin-inline-start');
-    });
-
-    it('should apply margin-block-start for column-reverse layouts', () => {
-      verifyCorrectMargin('column-reverse', 'margin-block-start');
-    });
-
-    it('should remove obsolete margin and apply valid margin for layout changes', () => {
-      createTestComponent(`
-          <div [fxLayout]='direction' [fxLayoutGap]='gap'>
-              <span></span>
-              <span></span>
-          </div>
-      `);
-      const instance = fixture.componentInstance;
-
-      // layout = column, use margin-top
-      instance.direction = 'column';
-      instance.gap = '8px';
-      fixture.detectChanges();
-      let nodes = queryFor(fixture, 'span');
-
-      expectEl(nodes[0]).not.toHaveStyle(
-        { 'margin-inline-end': '8px' },
-        styler,
-      );
-      expectEl(nodes[0]).toHaveStyle({ 'margin-block-end': '8px' }, styler);
-
-      // layout = column-reverse, use margin-block-start
-      instance.direction = 'column-reverse';
-      fixture.detectChanges();
-      nodes = queryFor(fixture, 'span');
-
-      expectEl(nodes[0]).not.toHaveStyle(
-        { 'margin-inline-end': '8px' },
-        styler,
-      );
-      expectEl(nodes[0]).toHaveStyle({ 'margin-block-start': '8px' }, styler);
-
-      // layout = row-reverse, use margin-inline-start
-      instance.direction = 'row-reverse';
-      fixture.detectChanges();
-      nodes = queryFor(fixture, 'span');
-
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-block-end': '8px' }, styler);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-start': '8px' }, styler);
-    });
-
-    it('should recognize hidden elements when applying gaps', () => {
-      const styles = ['.col1 { display:none !important;'];
-      const template = `
-        <div class='container' fxLayout='row' fxLayoutGap='16px'>
-          <div fxFlex class='col1'>Div 1</div>
-          <div fxFlex class='col2'>Div 2</div>
-          <div fxFlex class='col3'>Div 3</div>
-        </div>
-      `;
-      createTestComponent(template, styles);
-      fixture.componentInstance.direction = 'row';
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-
-      expect(nodes.length).toEqual(3);
-      // TODO(CaerusKaru): Domino is unable to detect this style
-      if (!isPlatformServer(platformId)) {
-        expectEl(nodes[0]).not.toHaveStyle(
-          { 'margin-inline-end': '0px' },
-          styler,
-        );
-        expectEl(nodes[0]).not.toHaveStyle(
-          { 'margin-inline-end': '16px' },
-          styler,
-        );
-        expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '16px' }, styler);
-        expectEl(nodes[2]).not.toHaveStyle(
-          { 'margin-inline-end': '16px' },
-          styler,
-        );
-      }
-    });
-
-    it('should adjust gaps based on layout-wrap presence', () => {
-      const styles = ['.col1 { display:none !important;'];
-      const template = `
-            <div class='container'
-                 [fxLayout]='direction + " wrap"'
-                 [fxLayoutGap]='gap'>
-              <div fxFlex class='col1'>Div 1</div>
-              <div fxFlex class='col2'>Div 2</div>
-              <div fxFlex class='col3'>Div 2</div>
-              <div fxFlex class='col4'>Div 3</div>
-            </div>
-          `;
-      createTestComponent(template, styles);
-      fixture.componentInstance.gap = '16px';
-      fixture.componentInstance.direction = 'row';
-      fixture.detectChanges();
-
-      let nodes = queryFor(fixture, '[fxFlex]');
-
-      expect(nodes.length).toEqual(4);
-      // TODO(CaerusKaru): Domino is unable to detect this style
-      if (!isPlatformServer(platformId)) {
-        expectEl(nodes[0]).not.toHaveStyle(
-          { 'margin-inline-end': '16px' },
-          styler,
-        );
-        expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '16px' }, styler);
-        expectEl(nodes[2]).toHaveStyle({ 'margin-inline-end': '16px' }, styler);
-        expectEl(nodes[3]).not.toHaveStyle(
-          { 'margin-inline-end': '16px' },
-          styler,
-        );
-      }
-
-      fixture.componentInstance.gap = '8px';
-      fixture.componentInstance.direction = 'column';
-      fixture.detectChanges();
-
-      nodes = queryFor(fixture, '[fxFlex]');
-
-      expect(nodes.length).toEqual(4);
-      // TODO(CaerusKaru): Domino is unable to detect this style
-      if (!isPlatformServer(platformId)) {
-        expectEl(nodes[0]).not.toHaveStyle(
-          { 'margin-block-end': '8px' },
-          styler,
-        );
-        expectEl(nodes[1]).toHaveStyle({ 'margin-block-end': '8px' }, styler);
-        expectEl(nodes[2]).toHaveStyle({ 'margin-block-end': '8px' }, styler);
-        expectEl(nodes[3]).not.toHaveStyle(
-          { 'margin-block-end': '8px' },
-          styler,
-        );
-      }
+    it('should set the same gap for a column layout', () => {
+      verifyContainerGap('column', '8px');
     });
   });
 
-  describe('with responsive features', () => {
-    it('should set gap on breakpoint change', () => {
-      const template = `
-        <div fxLayoutAlign='center center' fxLayoutGap='13px' fxLayoutGap.md="24px">
-          <div fxFlex></div>
-          <div fxFlex></div>
-          <div fxFlex></div>
-        </div>
-      `;
-      createTestComponent(template);
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-      expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle(
-        { 'margin-inline-end': '13px' },
-        styler,
-      );
-      expectEl(nodes[2]).not.toHaveStyle(
-        { 'margin-inline-end': '0px' },
-        styler,
-      );
-
-      mediaController.activate('md');
-      fixture.detectChanges();
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '24px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle(
-        { 'margin-inline-end': '24px' },
-        styler,
-      );
-      expectEl(nodes[2]).not.toHaveStyle(
-        { 'margin-inline-end': '0px' },
-        styler,
-      );
-    });
-
-    it('should set gap without fallback', () => {
-      const template = `
-        <div fxLayoutAlign='center center' fxLayoutGap.md="24px">
-          <div fxFlex></div>
-          <div fxFlex></div>
-          <div fxFlex></div>
-        </div>
-      `;
-      createTestComponent(template);
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-      expect(nodes.length).toEqual(3);
-      mediaController.activate('sm');
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-
-      mediaController.activate('md');
-      fixture.detectChanges();
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '24px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle(
-        { 'margin-inline-end': '24px' },
-        styler,
-      );
-      expectEl(nodes[2]).not.toHaveStyle(
-        { 'margin-inline-end': '0px' },
-        styler,
-      );
-
-      mediaController.activate('sm');
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-    });
-
-    it('should set gap with responsive layout change', () => {
-      const template = `
-        <div fxLayout="row" fxLayout.xs="column" fxLayoutGap="24px">
-          <div fxFlex></div>
-          <div fxFlex></div>
-          <div fxFlex></div>
-        </div>
-      `;
-      createTestComponent(template);
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-      expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '24px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-
-      mediaController.activate('xs');
-      fixture.detectChanges();
-      expectEl(nodes[0]).toHaveStyle({ 'margin-block-end': '24px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-block-end': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
-    });
-
-    it('should remove gaps with responsive layout change', () => {
-      const template = `
-        <div fxLayout="row" fxLayout.xs="column" fxLayoutGap.xs="24px">
-          <div fxFlex></div>
-          <div fxFlex></div>
-          <div fxFlex></div>
-        </div>
-      `;
-      createTestComponent(template);
-      const nodes = queryFor(fixture, '[fxFlex]');
-
-      mediaController.activate('md');
-      fixture.detectChanges();
-      expectEl(nodes[0]).not.toHaveStyle(
-        { 'margin-block-end': '24px' },
-        styler,
-      );
-      expectEl(nodes[1]).not.toHaveStyle(
-        { 'margin-block-end': '24px' },
-        styler,
-      );
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
-
-      mediaController.activate('xs');
-      fixture.detectChanges();
-      expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-block-end': '24px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-block-end': '24px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
-
-      mediaController.activate('md');
-      fixture.detectChanges();
-      expectEl(nodes[0]).not.toHaveStyle(
-        { 'margin-block-end': '24px' },
-        styler,
-      );
-      expectEl(nodes[1]).not.toHaveStyle(
-        { 'margin-block-end': '24px' },
-        styler,
-      );
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
-    });
-
-    it('should add gap styles in proper order when order style is applied on responsive layout change', () => {
-      const template = `
-        <div fxLayout="row" fxLayoutAlign="space-evenly center" fxLayout.xs="column" fxLayoutGap.xs="20px">
-          <div fxFlex fxFlexOrder.xs="3"></div>
-          <div fxFlex fxFlexOrder.xs="2"></div>
-          <div fxFlex fxFlexOrder.xs="1"></div>
-        </div>
-      `;
-      createTestComponent(template);
-      const nodes = queryFor(fixture, '[fxFlex]');
-
-      mediaController.activate('md');
-      fixture.detectChanges();
-      expect(nodes.length).toEqual(3);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
-
-      mediaController.activate('xs');
-      fixture.detectChanges();
-      expectEl(nodes[2]).toHaveStyle({ 'margin-block-end': '20px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-block-end': '20px' }, styler);
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-block-end': '*' }, styler);
-    });
-
-    it('should work with dynamic fxHide', () => {
-      const template = `
-        <div fxLayout="row" fxLayoutGap="10px">
-          <div fxFlex>A</div>
-          <div fxFlex [fxHide]="shouldHide">B</div>
-        </div>
-      `;
-      createTestComponent(template);
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-      expect(nodes.length).toEqual(2);
-      expectEl(nodes[0]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-
-      const instance = fixture.componentInstance;
-      instance.shouldHide = false;
-      fixture.detectChanges();
-
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '10px' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-    });
-
-    it('should work with responsive fxHide', () => {
-      const template = `
-        <div fxLayoutAlign="center center" fxLayoutGap="13px">
-          <div fxFlex="15" class="sec1" fxFlex.xs="55"></div>
-          <div fxFlex="30" class="sec2" fxFlex.sm></div>
-          <div fxFlex="55" class="sec3" fxShow fxHide.sm></div>
-        </div>
-      `;
-      createTestComponent(template);
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-      expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-
-      mediaController.activate('sm');
-      fixture.detectChanges();
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-
-      mediaController.activate('lg');
-      fixture.detectChanges();
-      expectEl(nodes[0]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[1]).toHaveStyle({ 'margin-inline-end': '13px' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'margin-inline-end': '*' }, styler);
-    });
-  });
-
-  describe('rtl support', () => {
-    // Logical properties (margin-inline-end) are direction-independent: the
-    // directive emits the same property regardless of `dir`, and the browser
-    // resolves it against the writing direction. See issue #95.
-    it('uses margin-inline-end when document body has rtl dir', () => {
-      fakeDocument.body.dir = 'rtl';
-      verifyCorrectMargin('row', 'margin-inline-end');
-    });
-
-    it('uses margin-inline-end when documentElement has rtl dir', () => {
-      fakeDocument.documentElement.dir = 'rtl';
-      verifyCorrectMargin('row', 'margin-inline-end');
-    });
-
-    it('still uses margin-block-end in column layout when body has rtl dir', () => {
-      fakeDocument.body.dir = 'rtl';
-      verifyCorrectMargin('column', 'margin-block-end');
-    });
-  });
-
-  describe('grid option', () => {
-    it('should add gap styles correctly', () => {
+  describe('legacy grid option', () => {
+    // The ' grid' suffix is retained for backwards compatibility but is now a
+    // no-op modifier: CSS `gap` already handles wrapped rows, so the value is
+    // emitted as a plain `gap` with no child padding or negative host margin.
+    it('should treat the grid suffix as a plain gap', () => {
       const template = `
         <div fxLayoutGap='13px grid'>
           <div fxFlex></div>
@@ -730,140 +184,85 @@ describe('layout-gap directive', () => {
         </div>
       `;
       createTestComponent(template);
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-      const expectedMargin = {
-        'margin-inline': '0px -13px',
-        'margin-block': '0px -13px',
-      };
-      const expectedPadding = {
-        'padding-inline': '0px 13px',
-        'padding-block': '0px 13px',
-      };
-      expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle(expectedPadding, styler);
-      expectEl(nodes[1]).toHaveStyle(expectedPadding, styler);
-      expectEl(nodes[2]).toHaveStyle(expectedPadding, styler);
-      expectNativeEl(fixture).toHaveStyle(expectedMargin, styler);
+      expectNativeEl(fixture).toHaveStyle({ gap: '13px' }, styler);
     });
 
-    it('should add gap styles correctly w/ multiplier', () => {
+    it('should apply the multiplier with the grid suffix', () => {
       const template = `
         <div fxLayoutGap='13x grid'>
           <div fxFlex></div>
           <div fxFlex></div>
-          <div fxFlex></div>
         </div>
       `;
       createTestComponent(template);
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-      const expectedMargin = {
-        'margin-inline': '0px -52px',
-        'margin-block': '0px -52px',
-      };
-      const expectedPadding = {
-        'padding-inline': '0px 52px',
-        'padding-block': '0px 52px',
-      };
-      expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle(expectedPadding, styler);
-      expectEl(nodes[1]).toHaveStyle(expectedPadding, styler);
-      expectEl(nodes[2]).toHaveStyle(expectedPadding, styler);
-      expectNativeEl(fixture).toHaveStyle(expectedMargin, styler);
+      expectNativeEl(fixture).toHaveStyle({ gap: '52px' }, styler);
     });
 
-    it('should add gap styles correctly between option', () => {
+    it('should support two values with the grid suffix', () => {
       const template = `
         <div fxLayoutGap='13px 12px grid'>
           <div fxFlex></div>
           <div fxFlex></div>
+        </div>
+      `;
+      createTestComponent(template);
+      expectNativeEl(fixture).toHaveStyle({ gap: '13px 12px' }, styler);
+    });
+  });
+
+  describe('with responsive features', () => {
+    it('should update the gap on breakpoint activation', () => {
+      const template = `
+        <div fxLayout='row' fxLayoutGap='8px' fxLayoutGap.xs='16px'>
+          <div fxFlex></div>
           <div fxFlex></div>
         </div>
       `;
       createTestComponent(template);
-      fixture.detectChanges();
+      expectNativeEl(fixture).toHaveStyle({ gap: '8px' }, styler);
 
-      const nodes = queryFor(fixture, '[fxFlex]');
-      const expectedMargin = {
-        'margin-inline': '0px -13px',
-        'margin-block': '0px -12px',
-      };
-      const expectedPadding = {
-        'padding-inline': '0px 13px',
-        'padding-block': '0px 12px',
-      };
-      expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle(expectedPadding, styler);
-      expectEl(nodes[1]).toHaveStyle(expectedPadding, styler);
-      expectEl(nodes[2]).toHaveStyle(expectedPadding, styler);
-      expectNativeEl(fixture).toHaveStyle(expectedMargin, styler);
+      mediaController.activate('xs');
+      expectNativeEl(fixture).toHaveStyle({ gap: '16px' }, styler);
+
+      mediaController.activate('lg');
+      expectNativeEl(fixture).toHaveStyle({ gap: '8px' }, styler);
     });
 
-    it('should set gap without fallback', () => {
+    it('should clear the gap when a breakpoint-only value deactivates', () => {
       const template = `
-        <div fxLayoutAlign='center center' fxLayoutGap.md="24px grid">
-          <div fxFlex></div>
+        <div fxLayout='row' fxLayoutGap.md='24px'>
           <div fxFlex></div>
           <div fxFlex></div>
         </div>
       `;
       createTestComponent(template);
-      fixture.detectChanges();
-
-      const nodes = queryFor(fixture, '[fxFlex]');
-      expect(nodes.length).toEqual(3);
       mediaController.activate('sm');
-      expectEl(nodes[0]).not.toHaveStyle({ 'padding-inline': '*' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'padding-inline': '*' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'padding-inline': '*' }, styler);
+      expectNativeEl(fixture).not.toHaveStyle({ gap: '*' }, styler);
 
       mediaController.activate('md');
-      fixture.detectChanges();
-      const expectedPadding = {
-        'padding-inline': '0px 24px',
-        'padding-block': '0px 24px',
-      };
-      expectEl(nodes[0]).toHaveStyle(expectedPadding, styler);
-      expectEl(nodes[1]).toHaveStyle(expectedPadding, styler);
-      expectEl(nodes[2]).toHaveStyle(expectedPadding, styler);
+      expectNativeEl(fixture).toHaveStyle({ gap: '24px' }, styler);
 
       mediaController.activate('sm');
-      expectEl(nodes[0]).not.toHaveStyle({ 'padding-inline': '*' }, styler);
-      expectEl(nodes[1]).not.toHaveStyle({ 'padding-inline': '*' }, styler);
-      expectEl(nodes[2]).not.toHaveStyle({ 'padding-inline': '*' }, styler);
+      expectNativeEl(fixture).not.toHaveStyle({ gap: '*' }, styler);
+    });
+  });
+
+  describe('rtl support', () => {
+    // The CSS `gap` property has no notion of side, so the emitted value is
+    // identical regardless of the document writing direction.
+    it('should use the same gap when document body has rtl dir', () => {
+      fakeDocument.body.dir = 'rtl';
+      verifyContainerGap('row', '8px');
     });
 
-    it('should add gap styles correctly for rtl', () => {
-      // Logical properties are direction-independent, so the emitted styles are
-      // identical to the ltr case; the browser resolves them against `rtl`.
-      fakeDocument.body.dir = 'rtl';
-      const template = `
-        <div fxLayoutGap='13px grid'>
-          <div fxFlex></div>
-          <div fxFlex></div>
-          <div fxFlex></div>
-        </div>
-      `;
-      createTestComponent(template);
-      fixture.detectChanges();
+    it('should use the same gap when documentElement has rtl dir', () => {
+      fakeDocument.documentElement.dir = 'rtl';
+      verifyContainerGap('row', '8px');
+    });
 
-      const nodes = queryFor(fixture, '[fxFlex]');
-      const expectedMargin = {
-        'margin-inline': '0px -13px',
-        'margin-block': '0px -13px',
-      };
-      const expectedPadding = {
-        'padding-inline': '0px 13px',
-        'padding-block': '0px 13px',
-      };
-      expect(nodes.length).toEqual(3);
-      expectEl(nodes[0]).toHaveStyle(expectedPadding, styler);
-      expectEl(nodes[1]).toHaveStyle(expectedPadding, styler);
-      expectEl(nodes[2]).toHaveStyle(expectedPadding, styler);
-      expectNativeEl(fixture).toHaveStyle(expectedMargin, styler);
+    it('should use the same gap in column layout when body has rtl dir', () => {
+      fakeDocument.body.dir = 'rtl';
+      verifyContainerGap('column', '8px');
     });
   });
 
@@ -887,10 +286,10 @@ describe('layout-gap directive', () => {
       });
     });
 
-    it('should set gap not to input', () => {
+    it('should use the configured style builder', () => {
       createTestComponent(`
         <div fxLayoutGap='10px'>
-          <div fxFlexOffset="25"></div>
+          <div fxFlex></div>
         </div>
       `);
       expectNativeEl(fixture).toHaveStyle({ 'margin-top': '12px' }, styler);
@@ -918,14 +317,10 @@ export class MockLayoutGapStyleBuilder extends StyleBuilder {
     DefaultLayoutDirective,
     DefaultLayoutGapDirective,
     DefaultFlexDirective,
-    DefaultFlexOrderDirective,
-    DefaultShowHideDirective,
   ],
 })
 class TestLayoutGapComponent implements OnInit {
   ngOnInit(): void {}
   direction = 'column';
   gap = '8px';
-  shouldHide = true;
-  rows = new Array(4);
 }

--- a/projects/libs/flex-layout/flex/layout-gap/layout-gap.ts
+++ b/projects/libs/flex-layout/flex/layout-gap/layout-gap.ts
@@ -1,17 +1,6 @@
-/* eslint-disable prefer-const */
-import {
-  AfterContentInit,
-  Directive,
-  ElementRef,
-  Inject,
-  Injectable,
-  NgZone,
-  OnDestroy,
-} from '@angular/core';
-import { LAYOUT_VALUES } from '@ngbracket/ngx-layout/_private-utils';
+import { Directive, ElementRef, Inject, Injectable } from '@angular/core';
 import {
   BaseDirective2,
-  ElementMatcher,
   LAYOUT_CONFIG,
   LayoutConfigOptions,
   MediaMarshaller,
@@ -20,71 +9,46 @@ import {
   StyleUtils,
   ɵmultiply as multiply,
 } from '@ngbracket/ngx-layout/core';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
-
-export interface LayoutGapParent {
-  items: HTMLElement[];
-  layout: string;
-}
-
-const CLEAR_MARGIN_CSS = {
-  'margin-inline-start': null,
-  'margin-inline-end': null,
-  'margin-block-start': null,
-  'margin-block-end': null,
-};
 
 @Injectable({ providedIn: 'root' })
 export class LayoutGapStyleBuilder extends StyleBuilder {
-  constructor(
-    private _styler: StyleUtils,
-    @Inject(LAYOUT_CONFIG) private _config: LayoutConfigOptions,
-  ) {
+  constructor(@Inject(LAYOUT_CONFIG) private _config: LayoutConfigOptions) {
     super();
   }
 
-  buildStyles(gapValue: string, parent: LayoutGapParent) {
+  buildStyles(gapValue: string): StyleDefinition {
+    // The ' grid' specifier is retained for backwards compatibility, but is no
+    // longer meaningful: the CSS `gap` property already spaces items within and
+    // between wrapped rows, which is what grid mode previously emulated with
+    // negative margins and child padding.
     if (gapValue.endsWith(GRID_SPECIFIER)) {
       gapValue = gapValue.slice(0, gapValue.indexOf(GRID_SPECIFIER));
-      gapValue = multiply(gapValue, this._config.multiplier);
+    }
 
-      // Add the margin to the host element
-      return buildGridMargin(gapValue);
-    } else {
+    gapValue = gapValue.trim();
+    if (!gapValue) {
       return {};
     }
+
+    return { gap: this.computeGap(gapValue) };
   }
 
-  override sideEffect(
-    gapValue: string,
-    _styles: StyleDefinition,
-    parent: LayoutGapParent,
-  ) {
-    const items = parent.items;
-    if (gapValue.endsWith(GRID_SPECIFIER)) {
-      gapValue = gapValue.slice(0, gapValue.indexOf(GRID_SPECIFIER));
-      gapValue = multiply(gapValue, this._config.multiplier);
-      // For each `element` children, set the padding
-      const paddingStyles = buildGridPadding(gapValue);
-      this._styler.applyStyleToElements(paddingStyles, parent.items);
-    } else {
-      gapValue = multiply(gapValue, this._config.multiplier);
-      gapValue = this.addFallbackUnit(gapValue);
-
-      const lastItem = items.pop()!;
-
-      // For each `element` children EXCEPT the last,
-      // set the margin right/bottom styles...
-      const gapCss = buildGapCSS(gapValue, parent);
-      this._styler.applyStyleToElements(gapCss, items);
-
-      // Clear all gaps for all visible elements
-      this._styler.applyStyleToElements(CLEAR_MARGIN_CSS, [lastItem]);
-    }
+  /**
+   * `gapValue` may contain one or two space-separated tokens, mapped directly to
+   * the CSS `gap` shorthand (`<row-gap> <column-gap>`). The multiplier and the
+   * default unit are applied to each token independently.
+   */
+  private computeGap(gapValue: string): string {
+    return gapValue
+      .split(' ')
+      .filter((token) => token !== '')
+      .map((token) =>
+        this.addFallbackUnit(multiply(token, this._config.multiplier)),
+      )
+      .join(' ');
   }
 
-  private addFallbackUnit(value: string) {
+  private addFallbackUnit(value: string): string {
     return !isNaN(+value) ? `${value}${this._config.defaultUnit}` : value;
   }
 }
@@ -113,165 +77,25 @@ const selector = `
 `;
 
 /**
- * 'layout-padding' styling directive
- *  Defines padding of child elements in a layout container
+ * 'layout-gap' styling directive
+ *  Defines the spacing between child elements of a flex container using the
+ *  native CSS `gap` property. The gap is applied to the container itself, so it
+ *  spaces items both within a row/column and between wrapped rows.
  */
 @Directive({ inputs, selector })
-export class LayoutGapDirective
-  extends BaseDirective2
-  implements AfterContentInit, OnDestroy
-{
-  protected layout = 'row'; // default flex-direction
+export class LayoutGapDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'layout-gap';
   protected override inputs = inputs;
-  protected observerSubject = new Subject<void>();
-
-  /** Special accessor to query for all child 'element' nodes regardless of type, class, etc */
-  protected get childrenNodes(): HTMLElement[] {
-    const obj = this.nativeElement.children;
-    const buffer: any[] = [];
-
-    // iterate backwards ensuring that length is an UInt32
-    for (let i = obj.length; i--; ) {
-      buffer[i] = obj[i];
-    }
-    return buffer;
-  }
 
   constructor(
     elRef: ElementRef,
-    protected zone: NgZone,
-    protected styleUtils: StyleUtils,
+    styler: StyleUtils,
     styleBuilder: LayoutGapStyleBuilder,
     marshal: MediaMarshaller,
   ) {
-    super(elRef, styleBuilder, styleUtils, marshal);
-    const extraTriggers = [this.observerSubject.asObservable()];
-    this.init(extraTriggers);
-    this.marshal
-      .trackValue(this.nativeElement, 'layout')
-      .pipe(takeUntil(this.destroySubject))
-      .subscribe(this.onLayoutChange.bind(this));
+    super(elRef, styleBuilder, styler, marshal);
+    this.init();
   }
-
-  // *********************************************
-  // Lifecycle Methods
-  // *********************************************
-
-  ngAfterContentInit() {
-    this.buildChildObservable();
-    this.triggerUpdate();
-  }
-
-  override ngOnDestroy() {
-    super.ngOnDestroy();
-    if (this.observer) {
-      this.observer.disconnect();
-    }
-  }
-
-  // *********************************************
-  // Protected methods
-  // *********************************************
-
-  /**
-   * Cache the parent container 'flex-direction' and update the 'margin' styles
-   */
-  protected onLayoutChange(matcher: ElementMatcher) {
-    const layout: string = matcher.value;
-
-    // Make sure to filter out 'wrap' option
-    let newDirection = layout.split(' ')[0];
-
-    if (!LAYOUT_VALUES.find((x) => x === newDirection)) {
-      newDirection = 'row';
-    }
-
-    // Clear the previous style before we change the layout
-    if (this.layout && this.layout !== newDirection) {
-      this.clearStyles();
-    }
-
-    this.layout = newDirection;
-    this.triggerUpdate();
-  }
-
-  /**
-   *
-   */
-  protected override updateWithValue(value: string) {
-    // Gather all non-hidden Element nodes
-    const items = this.childrenNodes
-      .filter((el) => el.nodeType === 1 && this.willDisplay(el))
-      .sort((a, b) => {
-        const orderA = +this.styler.lookupStyle(a, 'order');
-        const orderB = +this.styler.lookupStyle(b, 'order');
-        if (isNaN(orderA) || isNaN(orderB) || orderA === orderB) {
-          return 0;
-        } else {
-          return orderA > orderB ? 1 : -1;
-        }
-      });
-
-    if (items.length > 0) {
-      this.addStyles(value, { items, layout: this.layout });
-    }
-  }
-
-  /** We need to override clearStyles because in most cases mru isn't populated */
-  protected override clearStyles() {
-    const gridMode = Object.keys(this.mru).length > 0;
-
-    // If there are styles on the parent remove them
-    if (gridMode) {
-      super.clearStyles();
-
-      // Then remove the children grid padding too
-      this.styleUtils.applyStyleToElements(
-        { 'padding-inline': '', 'padding-block': '' },
-        this.childrenNodes,
-      );
-    } else {
-      // Remove the children gap margin
-      this.styleUtils.applyStyleToElements(
-        { [getMarginType(this.layout)]: '' },
-        this.childrenNodes,
-      );
-    }
-  }
-
-  /** Determine if an element will show or hide based on current activation */
-  protected willDisplay(source: HTMLElement): boolean {
-    const value = this.marshal.getValue(source, 'show-hide');
-    return (
-      value === true ||
-      (value === undefined &&
-        this.styleUtils.lookupStyle(source, 'display') !== 'none')
-    );
-  }
-
-  protected buildChildObservable(): void {
-    this.zone.runOutsideAngular(() => {
-      if (typeof MutationObserver !== 'undefined') {
-        this.observer = new MutationObserver((mutations: MutationRecord[]) => {
-          const validatedChanges = (it: MutationRecord): boolean => {
-            return (
-              (it.addedNodes && it.addedNodes.length > 0) ||
-              (it.removedNodes && it.removedNodes.length > 0)
-            );
-          };
-
-          // update gap styles only for child 'added' or 'removed' events
-          if (mutations.some(validatedChanges)) {
-            this.observerSubject.next();
-          }
-        });
-        this.observer.observe(this.nativeElement, { childList: true });
-      }
-    });
-  }
-
-  protected observer?: MutationObserver;
 }
 
 /**
@@ -284,53 +108,3 @@ export class DefaultLayoutGapDirective extends LayoutGapDirective {
 }
 
 const GRID_SPECIFIER = ' grid';
-
-function buildGridPadding(value: string): StyleDefinition {
-  const [between, below] = value.split(' ');
-  const bottom = below ?? between;
-
-  // Use logical properties so the gap follows the writing direction
-  // (e.g. `direction: rtl`) without inspecting the directionality.
-  return {
-    'padding-inline': `0px ${between}`,
-    'padding-block': `0px ${bottom}`,
-  };
-}
-
-function buildGridMargin(value: string): StyleDefinition {
-  const [between, below] = value.split(' ');
-  const bottom = below ?? between;
-  const minus = (str: string) => `-${str}`;
-
-  // Use logical properties so the gap follows the writing direction
-  // (e.g. `direction: rtl`) without inspecting the directionality.
-  return {
-    'margin-inline': `0px ${minus(between)}`,
-    'margin-block': `0px ${minus(bottom)}`,
-  };
-}
-
-function getMarginType(layout: string) {
-  switch (layout) {
-    case 'column':
-      return 'margin-block-end';
-    case 'column-reverse':
-      return 'margin-block-start';
-    case 'row':
-      return 'margin-inline-end';
-    case 'row-reverse':
-      return 'margin-inline-start';
-    default:
-      return 'margin-inline-end';
-  }
-}
-
-function buildGapCSS(
-  gapValue: string,
-  parent: { layout: string },
-): StyleDefinition {
-  const key = getMarginType(parent.layout);
-  const margins: { [key: string]: string | null } = { ...CLEAR_MARGIN_CSS };
-  margins[key] = gapValue;
-  return margins;
-}


### PR DESCRIPTION
## Summary

Fixes #43 — `fxLayout="row wrap"` + `fxLayoutGap` rendering inconsistencies.

`fxLayoutGap` previously applied `margin` to each child except the last. This caused two bugs the reporter documented:

1. **No spacing between wrapped rows** (gap only applied along the main axis).
2. **Extra leading margin on the last/short wrapped row.**

This PR switches `fxLayoutGap` to set the native CSS **`gap`** property on the flex container itself. `gap` spaces items both within a row/column **and between wrapped rows**, which fixes both issues. It's also direction-agnostic, so RTL and reversed flows need no special casing.

## Changes

- **`layout-gap.ts`** — `LayoutGapStyleBuilder.buildStyles` now returns `{ gap }` applied to the host. Removed the `MutationObserver`, child querying/sorting, layout-direction tracking, and the grid negative-margin/padding machinery (`buildGridMargin`/`buildGridPadding`/`getMarginType`/`buildGapCSS`/`CLEAR_MARGIN_CSS`). `BaseDirective2`'s default update path applies the gap. Net −820 lines.
  - One value → `gap: X` (row + column). Two values → CSS `gap` shorthand `<row-gap> <column-gap>`.
  - Multiplier and default unit applied per token.
- **`layout-gap.spec.ts`** — replaced the margin/child-based suite with a focused suite asserting `gap` on the container (static values, multiplier, default unit, two-value, responsive activate/clear, RTL no-op, legacy `grid` suffix).
- **`fxLayoutGap-API.md`** — documented the new behavior and the breaking change.

## Breaking change

`fxLayoutGap` now emits CSS `gap` on the container rather than `margin` on children, so the element must be a flex container (apply `fxLayout`) for the gap to take effect. The legacy `" grid"` suffix (e.g. `fxLayoutGap="10px grid"`) is still accepted but is now equivalent to a plain gap, since `gap` already handles wrapped rows.

## Verification

- `ng test @ngbracket/ngx-layout` — **464 tests pass** (incl. rewritten layout-gap suite; flex/layout-align/show-hide/grid specs that interact via the `layout-gap` marshaller key still pass)
- `ng build @ngbracket/ngx-layout` — builds clean

cc @Alexi996 — this implements the CSS `gap` approach you proposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)