### PR TITLE
feat(breakpoints): add opt-in MATERIAL_BREAKPOINTS preset (#26)

### DIFF
--- a/projects/apps/docs/documentation/docs/breakpoints/breakpoints.md
+++ b/projects/apps/docs/documentation/docs/breakpoints/breakpoints.md
@@ -77,17 +77,56 @@ With the above changes, when printing on mobile-sized viewports the xs.print med
 
 Thus, you can use the token to segment which breakpoints you provide and in which order. For instance, you can provide all print breakpoints in an array called `PRINT_BREAKPOINTS` and then all mobile breakpoints in another array called `MOBILE_BREAKPOINTS`. You can also simply provide one additional breakpoint if that's all you need.
 
-## Disabling the default breakpoints
+## Material breakpoints preset
 
-To disable the default breakpoints, you simply provide the new **DISABLE_DEFAULT_BREAKPOINTS** token as follows:
+The library's `DEFAULT_BREAKPOINTS` retain the original `@angular/flex-layout`
+ranges, where `md` starts at **960px**. If you prefer the modern Material Design 3
+ranges (`md` at **900px**), an opt-in `MATERIAL_BREAKPOINTS` preset is provided:
+
+| alias | range                |
+| ----- | -------------------- |
+| xs    | `< 600px`            |
+| sm    | `600px – 899.98px`   |
+| md    | `900px – 1199.98px`  |
+| lg    | `1200px – 1535.98px` |
+| xl    | `>= 1536px`          |
+
+To use it, disable the default breakpoints and provide the preset:
 
 ```typescript
-import {DISABLE_DEFAULT_BREAKPOINTS} from '@ngbracket/ngx-layout';
+import { FlexLayoutModule, MATERIAL_BREAKPOINTS } from '@ngbracket/ngx-layout';
 
-{provide: DISABLE_DEFAULT_BREAKPOINTS, useValue: true}
+FlexLayoutModule.withConfig({ disableDefaultBps: true }, MATERIAL_BREAKPOINTS);
 ```
 
-The default value for this breakpoint is false
+or, with the standalone provider:
+
+```typescript
+import { provideFlexLayout, MATERIAL_BREAKPOINTS } from '@ngbracket/ngx-layout';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideFlexLayout({ disableDefaultBps: true }, MATERIAL_BREAKPOINTS),
+  ],
+};
+```
+
+The preset uses the same `xs`/`sm`/`md`/`lg`/`xl` aliases (plus the `lt-*` and
+`gt-*` variants) as the defaults, so existing responsive selectors keep working —
+only the activation ranges change.
+
+## Disabling the default breakpoints
+
+To disable the default breakpoints, set the `disableDefaultBps` config option to
+`true` (for example via `FlexLayoutModule.withConfig` or `provideFlexLayout`):
+
+```typescript
+import { FlexLayoutModule } from '@ngbracket/ngx-layout';
+
+FlexLayoutModule.withConfig({ disableDefaultBps: true });
+```
+
+The default value for this option is `false`.
 
 ## Adding the orientation breakpoints
 

--- a/projects/libs/flex-layout/core/breakpoints/data/material-break-points.spec.ts
+++ b/projects/libs/flex-layout/core/breakpoints/data/material-break-points.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { TestBed, inject } from '@angular/core/testing';
+import { sortDescendingPriority } from '../../utils/sort';
+
+import { BreakPoint } from '../break-point';
+import { BREAKPOINTS } from '../break-points-token';
+import { mergeByAlias } from '../breakpoint-tools';
+import { MATERIAL_BREAKPOINTS } from './material-break-points';
+
+describe('material-break-points', () => {
+  let breakPoints: BreakPoint[];
+
+  beforeEach(() => {
+    // Configure testbed to prepare services
+    TestBed.configureTestingModule({
+      providers: [{ provide: BREAKPOINTS, useValue: MATERIAL_BREAKPOINTS }],
+    });
+  });
+  beforeEach(inject([BREAKPOINTS], (bps: BreakPoint[]) => {
+    breakPoints = [...bps].sort(sortDescendingPriority);
+  }));
+
+  it('exposes the same alias set as the default breakpoints', () => {
+    expect(breakPoints.length).toEqual(MATERIAL_BREAKPOINTS.length);
+    expect(breakPoints[0].alias).toEqual('xs');
+    expect(breakPoints[breakPoints.length - 1].alias).toEqual('gt-xs');
+  });
+
+  it('derives suffixes when consumed through the breakpoint factory', () => {
+    // The BREAKPOINTS factory merges provided breakpoints via `mergeByAlias`,
+    // which fills in the camel-cased `suffix` used to build responsive inputs.
+    const merged = mergeByAlias([], MATERIAL_BREAKPOINTS);
+    const md = merged.find((bp) => bp.alias === 'md');
+    const ltLg = merged.find((bp) => bp.alias === 'lt-lg');
+    expect(md!.suffix).toEqual('Md');
+    expect(ltLg!.suffix).toEqual('LtLg');
+  });
+
+  it('uses the modern Material 3 ranges (md starts at 900px)', () => {
+    const find = (alias: string) =>
+      breakPoints.find((bp) => bp.alias === alias)!;
+
+    expect(find('xs').mediaQuery).toContain('max-width: 599.98px');
+    expect(find('sm').mediaQuery).toContain('min-width: 600px');
+    expect(find('md').mediaQuery).toContain('min-width: 900px');
+    expect(find('md').mediaQuery).toContain('max-width: 1199.98px');
+    expect(find('lg').mediaQuery).toContain('min-width: 1200px');
+    expect(find('xl').mediaQuery).toContain('min-width: 1536px');
+  });
+});

--- a/projects/libs/flex-layout/core/breakpoints/data/material-break-points.ts
+++ b/projects/libs/flex-layout/core/breakpoints/data/material-break-points.ts
@@ -1,0 +1,101 @@
+import { BreakPoint } from '../break-point';
+
+/**
+ * Material Design 3 breakpoints, offered as an opt-in alternative to the
+ * library's {@link DEFAULT_BREAKPOINTS} (which retain the original
+ * `@angular/flex-layout` ranges where `md` starts at 960px).
+ *
+ * These match the widely-used modern Material breakpoint values:
+ *
+ *   xs | < 600px
+ *   sm | 600px – 899.98px
+ *   md | 900px – 1199.98px
+ *   lg | 1200px – 1535.98px
+ *   xl | >= 1536px
+ *
+ * To use them instead of the defaults, disable the built-ins and provide this
+ * set, e.g.:
+ *
+ *   FlexLayoutModule.withConfig({ disableDefaultBps: true }, MATERIAL_BREAKPOINTS)
+ *
+ * or, with the standalone provider:
+ *
+ *   provideFlexLayout({ disableDefaultBps: true }, MATERIAL_BREAKPOINTS)
+ *
+ * NOTE: Smaller ranges have HIGHER priority since the match is more specific.
+ */
+export const MATERIAL_BREAKPOINTS: BreakPoint[] = [
+  {
+    alias: 'xs',
+    mediaQuery: 'screen and (min-width: 0px) and (max-width: 599.98px)',
+    priority: 1000,
+  },
+  {
+    alias: 'sm',
+    mediaQuery: 'screen and (min-width: 600px) and (max-width: 899.98px)',
+    priority: 900,
+  },
+  {
+    alias: 'md',
+    mediaQuery: 'screen and (min-width: 900px) and (max-width: 1199.98px)',
+    priority: 800,
+  },
+  {
+    alias: 'lg',
+    mediaQuery: 'screen and (min-width: 1200px) and (max-width: 1535.98px)',
+    priority: 700,
+  },
+  {
+    alias: 'xl',
+    mediaQuery: 'screen and (min-width: 1536px) and (max-width: 4999.98px)',
+    priority: 600,
+  },
+  {
+    alias: 'lt-sm',
+    overlapping: true,
+    mediaQuery: 'screen and (max-width: 599.98px)',
+    priority: 950,
+  },
+  {
+    alias: 'lt-md',
+    overlapping: true,
+    mediaQuery: 'screen and (max-width: 899.98px)',
+    priority: 850,
+  },
+  {
+    alias: 'lt-lg',
+    overlapping: true,
+    mediaQuery: 'screen and (max-width: 1199.98px)',
+    priority: 750,
+  },
+  {
+    alias: 'lt-xl',
+    overlapping: true,
+    priority: 650,
+    mediaQuery: 'screen and (max-width: 1535.98px)',
+  },
+  {
+    alias: 'gt-xs',
+    overlapping: true,
+    mediaQuery: 'screen and (min-width: 600px)',
+    priority: -950,
+  },
+  {
+    alias: 'gt-sm',
+    overlapping: true,
+    mediaQuery: 'screen and (min-width: 900px)',
+    priority: -850,
+  },
+  {
+    alias: 'gt-md',
+    overlapping: true,
+    mediaQuery: 'screen and (min-width: 1200px)',
+    priority: -750,
+  },
+  {
+    alias: 'gt-lg',
+    overlapping: true,
+    mediaQuery: 'screen and (min-width: 1536px)',
+    priority: -650,
+  },
+];

--- a/projects/libs/flex-layout/core/breakpoints/index.ts
+++ b/projects/libs/flex-layout/core/breakpoints/index.ts
@@ -1,4 +1,5 @@
 export * from './data/break-points';
+export * from './data/material-break-points';
 export * from './data/orientation-break-points';
 
 export * from './break-point';


### PR DESCRIPTION
## Summary

Addresses #26 — *"Breakpoints are aged. Maybe adapt Bootstrap Breakpoints?"*

The default breakpoints retain the original `@angular/flex-layout` ranges, where `md` starts at **960px** — dated compared to modern libraries. Per the discussion on the issue, rather than change the defaults (a breaking change for `@angular/flex-layout` migrants), this adds an **opt-in** `MATERIAL_BREAKPOINTS` preset with modern Material 3 values.

Material was chosen deliberately — it's the closest fit and keeps the same alias scheme (Bootstrap/Tailwind would need an extra `xxl`/`2xl` tier).

| alias | range |
|---|---|
| xs | `< 600px` |
| sm | `600px – 899.98px` |
| **md** | **`900px – 1199.98px`** |
| lg | `1200px – 1535.98px` |
| xl | `>= 1536px` |

## Changes

- **`core/breakpoints/data/material-break-points.ts`** — new `MATERIAL_BREAKPOINTS: BreakPoint[]`, mirroring `DEFAULT_BREAKPOINTS` structure/priorities (same `xs/sm/md/lg/xl` + `lt-*`/`gt-*` aliases), with Material 3 ranges.
- **`core/breakpoints/index.ts`** — export the preset (available from `@ngbracket/ngx-layout` and `/core`).
- **`material-break-points.spec.ts`** — verifies the alias set, suffix derivation through `mergeByAlias`, and the Material ranges.
- **`docs/breakpoints/breakpoints.md`** — new "Material breakpoints preset" section; also corrected the "Disabling the default breakpoints" section, which referenced a non-existent `DISABLE_DEFAULT_BREAKPOINTS` token (the real option is the `disableDefaultBps` config flag).

## Usage

```typescript
import { FlexLayoutModule, MATERIAL_BREAKPOINTS } from '@ngbracket/ngx-layout';

FlexLayoutModule.withConfig({ disableDefaultBps: true }, MATERIAL_BREAKPOINTS);
```

or with the standalone provider:

```typescript
provideFlexLayout({ disableDefaultBps: true }, MATERIAL_BREAKPOINTS);
```

**Non-breaking:** defaults are untouched; this is purely additive. The preset reuses the existing alias set, so responsive selectors keep working — only the activation ranges change.

## Verification

- `ng test @ngbracket/ngx-layout` — **481 tests pass** (incl. the new preset spec)
- `ng build @ngbracket/ngx-layout` — builds clean; `MATERIAL_BREAKPOINTS` confirmed present in the built bundle

cc @Martin-Eckleben

🤖 Generated with [Claude Code](https://claude.com/claude-code)