### PR TITLE
refactor!: remove deprecated Default* directives

### DIFF
--- a/projects/apps/universal-demo-app/src/app/split/split-area.directive.ts
+++ b/projects/apps/universal-demo-app/src/app/split/split-area.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, Optional, Self } from '@angular/core';
-import { DefaultFlexDirective } from '@ngbracket/ngx-layout';
+import { FlexDirective } from '@ngbracket/ngx-layout';
 
 @Directive({
   selector: '[ngxSplitArea]',
@@ -8,5 +8,5 @@ import { DefaultFlexDirective } from '@ngbracket/ngx-layout';
   },
 })
 export class SplitAreaDirective {
-  constructor(@Optional() @Self() public flex: DefaultFlexDirective) {}
+  constructor(@Optional() @Self() public flex: FlexDirective) {}
 }

--- a/projects/libs/flex-layout/extended/class/class.spec.ts
+++ b/projects/libs/flex-layout/extended/class/class.spec.ts
@@ -21,7 +21,7 @@ import {
   ɵMockMatchMedia as MockMatchMedia,
   ɵMockMatchMediaProvider as MockMatchMediaProvider,
 } from '@ngbracket/ngx-layout/core';
-import { DefaultClassDirective } from '@ngbracket/ngx-layout/extended';
+import { ClassDirective } from '@ngbracket/ngx-layout/extended';
 
 import {
   expectNativeEl,
@@ -52,7 +52,7 @@ describe('class directive', () => {
         MatButtonModule,
         CommonModule,
         CoreModule,
-        DefaultClassDirective,
+        ClassDirective,
         TestClassComponent,
       ],
       providers: [MockMatchMediaProvider],
@@ -341,7 +341,7 @@ describe('class directive', () => {
   selector: 'test-class-api',
   template: `<span>PlaceHolder Template HTML</span>`,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [MatButtonModule, CommonModule, CoreModule, DefaultClassDirective],
+  imports: [MatButtonModule, CommonModule, CoreModule, ClassDirective],
 })
 class TestClassComponent {
   hasXs1: boolean = false;

--- a/projects/libs/flex-layout/extended/class/class.ts
+++ b/projects/libs/flex-layout/extended/class/class.ts
@@ -83,15 +83,3 @@ export class ClassDirective extends BaseDirective2 implements DoCheck {
     this.ngClassInstance.ngDoCheck();
   }
 }
-
-/**
- * Directive to add responsive support for ngClass.
- * This maintains the core functionality of 'ngClass' and adds responsive API
- * Note: this class is a no-op when rendered on the server
- * *  @deprecated The DefaultClassDirective will be removed in version 21.
- * Use ClassDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultClassDirective extends ClassDirective {
-  protected override inputs = inputs;
-}

--- a/projects/libs/flex-layout/extended/img-src/img-src.spec.ts
+++ b/projects/libs/flex-layout/extended/img-src/img-src.spec.ts
@@ -23,7 +23,7 @@ import {
   queryFor,
 } from '@ngbracket/ngx-layout/_private-utils/testing';
 import { FlexLayoutModule } from '../../module';
-import { DefaultImgSrcDirective } from '@ngbracket/ngx-layout/extended';
+import { ImgSrcDirective } from '@ngbracket/ngx-layout/extended';
 
 const SRC_URLS = {
   xs: [
@@ -375,7 +375,7 @@ describe('img-src directive', () => {
   selector: 'test-src-api',
   template: '',
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [CommonModule, DefaultImgSrcDirective],
+  imports: [CommonModule, ImgSrcDirective],
 })
 class TestSrcComponent {
   defaultSrc = '';

--- a/projects/libs/flex-layout/extended/img-src/img-src.ts
+++ b/projects/libs/flex-layout/extended/img-src/img-src.ts
@@ -94,20 +94,3 @@ export class ImgSrcDirective extends BaseDirective2 {
 }
 
 const imgSrcCache: Map<string, StyleDefinition> = new Map();
-
-/**
- *  *  @deprecated The DefaultImgSrcDirective will be removed in version 21.
- * Use ImgSrcDirective directly instead.
- *
- * This directive provides a responsive API for the HTML <img> 'src' attribute
- * and will update the img.src property upon each responsive activation.
- *
- * e.g.
- *      <img src="defaultScene.jpg" src.xs="mobileScene.jpg"></img>
- *
- * @see https://css-tricks.com/responsive-images-youre-just-changing-resolutions-use-src/
- */
-@Directive({ selector, inputs })
-export class DefaultImgSrcDirective extends ImgSrcDirective {
-  protected override inputs = inputs;
-}

--- a/projects/libs/flex-layout/extended/module.ts
+++ b/projects/libs/flex-layout/extended/module.ts
@@ -1,16 +1,16 @@
 import { NgModule } from '@angular/core';
 import { CoreModule } from '@ngbracket/ngx-layout/core';
 
-import { DefaultClassDirective } from './class/class';
-import { DefaultImgSrcDirective } from './img-src/img-src';
-import { DefaultShowHideDirective } from './show-hide/show-hide';
-import { DefaultStyleDirective } from './style/style';
+import { ClassDirective } from './class/class';
+import { ImgSrcDirective } from './img-src/img-src';
+import { ShowHideDirective } from './show-hide/show-hide';
+import { StyleDirective } from './style/style';
 
 const ALL_DIRECTIVES = [
-  DefaultShowHideDirective,
-  DefaultClassDirective,
-  DefaultStyleDirective,
-  DefaultImgSrcDirective,
+  ShowHideDirective,
+  ClassDirective,
+  StyleDirective,
+  ImgSrcDirective,
 ];
 
 /**

--- a/projects/libs/flex-layout/extended/show-hide/hide.spec.ts
+++ b/projects/libs/flex-layout/extended/show-hide/hide.spec.ts
@@ -24,11 +24,11 @@ import {
   queryFor,
 } from '@ngbracket/ngx-layout/_private-utils/testing';
 import { FlexLayoutModule } from '../../module';
-import { DefaultShowHideDirective } from '@ngbracket/ngx-layout/extended';
+import { ShowHideDirective } from '@ngbracket/ngx-layout/extended';
 import {
-  DefaultFlexDirective,
-  DefaultLayoutAlignDirective,
-  DefaultLayoutDirective,
+  FlexDirective,
+  LayoutAlignDirective,
+  LayoutDirective,
 } from '@ngbracket/ngx-layout/flex';
 
 describe('hide directive', () => {
@@ -377,10 +377,10 @@ describe('hide directive', () => {
   changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     CommonModule,
-    DefaultShowHideDirective,
-    DefaultLayoutDirective,
-    DefaultLayoutAlignDirective,
-    DefaultFlexDirective,
+    ShowHideDirective,
+    LayoutDirective,
+    LayoutAlignDirective,
+    FlexDirective,
   ],
 })
 class TestHideComponent {

--- a/projects/libs/flex-layout/extended/show-hide/show-hide.ts
+++ b/projects/libs/flex-layout/extended/show-hide/show-hide.ts
@@ -216,13 +216,3 @@ export class ShowHideDirective
 }
 
 const DISPLAY_MAP: WeakMap<HTMLElement, string> = new WeakMap();
-
-/**
- * 'show' Layout API directive
- *  @deprecated The DefaultShowHideDirective will be removed in version 21.
- * Use ShowHideDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultShowHideDirective extends ShowHideDirective {
-  protected override inputs = inputs;
-}

--- a/projects/libs/flex-layout/extended/show-hide/show.spec.ts
+++ b/projects/libs/flex-layout/extended/show-hide/show.spec.ts
@@ -19,11 +19,11 @@ import { MatFormFieldModule, MatLabel } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { FlexLayoutModule } from '@ngbracket/ngx-layout';
-import { DefaultShowHideDirective } from '@ngbracket/ngx-layout/extended';
+import { ShowHideDirective } from '@ngbracket/ngx-layout/extended';
 import {
-  DefaultFlexDirective,
-  DefaultLayoutAlignDirective,
-  DefaultLayoutDirective,
+  FlexDirective,
+  LayoutAlignDirective,
+  LayoutDirective,
 } from '@ngbracket/ngx-layout/flex';
 import {
   expectEl,
@@ -39,7 +39,6 @@ import {
   SERVER_TOKEN,
   StyleUtils,
 } from '@ngbracket/ngx-layout/core';
-import { ShowHideDirective } from '../../extended/show-hide/show-hide';
 
 describe('show directive', () => {
   let fixture: ComponentFixture<any>;
@@ -429,10 +428,10 @@ class FxShowHideDirective extends ShowHideDirective {
     FormsModule,
     MatSelectModule,
     MatLabel,
-    DefaultShowHideDirective,
-    DefaultLayoutDirective,
-    DefaultLayoutAlignDirective,
-    DefaultFlexDirective,
+    ShowHideDirective,
+    LayoutDirective,
+    LayoutAlignDirective,
+    FlexDirective,
     FxShowHideDirective,
   ],
 })

--- a/projects/libs/flex-layout/extended/style/style.ts
+++ b/projects/libs/flex-layout/extended/style/style.ts
@@ -137,20 +137,6 @@ export class StyleDirective extends BaseDirective2 implements DoCheck {
   }
 }
 
-/**
- * Directive to add responsive support for ngStyle.
- * * @deprecated The DefaultStyleDirective will be removed in version 21.
- * Use StyleDirective directly instead.
- *
- */
-/* @deprecated The DefaultStyleDirective will be removed in version 21.
- * Use StyleDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultStyleDirective extends StyleDirective implements DoCheck {
-  protected override inputs = inputs;
-}
-
 /** Build a styles map from a list of styles, while sanitizing bad values first */
 function buildMapFromList(
   styles: NgStyleRawList,

--- a/projects/libs/flex-layout/flex/flex-align/flex-align.ts
+++ b/projects/libs/flex-layout/flex/flex-align/flex-align.ts
@@ -77,12 +77,3 @@ export class FlexAlignDirective extends BaseDirective2 {
 }
 
 const flexAlignCache: Map<string, StyleDefinition> = new Map();
-
-/**
- * @deprecated The DefaultFlexAlignDirective will be removed in version 21.
- * Use FlexAlignDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultFlexAlignDirective extends FlexAlignDirective {
-  protected override inputs = inputs;
-}

--- a/projects/libs/flex-layout/flex/flex-offset/flex-offset.spec.ts
+++ b/projects/libs/flex-layout/flex/flex-offset/flex-offset.spec.ts
@@ -22,9 +22,9 @@ import {
   ɵMockMatchMediaProvider as MockMatchMediaProvider,
 } from '@ngbracket/ngx-layout/core';
 import {
-  DefaultFlexDirective,
-  DefaultFlexOffsetDirective,
-  DefaultLayoutDirective,
+  FlexDirective,
+  FlexOffsetDirective,
+  LayoutDirective,
   FlexModule,
   FlexOffsetStyleBuilder,
 } from '@ngbracket/ngx-layout/flex';
@@ -273,12 +273,7 @@ export class MockFlexOffsetStyleBuilder extends StyleBuilder {
   selector: 'test-component-shell',
   template: `<span>PlaceHolder Template HTML</span>`,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [
-    CommonModule,
-    DefaultLayoutDirective,
-    DefaultFlexDirective,
-    DefaultFlexOffsetDirective,
-  ],
+  imports: [CommonModule, LayoutDirective, FlexDirective, FlexOffsetDirective],
 })
 class TestFlexComponent {
   direction = 'column';

--- a/projects/libs/flex-layout/flex/flex-offset/flex-offset.ts
+++ b/projects/libs/flex-layout/flex/flex-offset/flex-offset.ts
@@ -123,15 +123,6 @@ export class FlexOffsetDirective extends BaseDirective2 implements OnChanges {
   }
 }
 
-/**
- * @deprecated The DefaultFlexOffsetDirective will be removed in version 21.
- * Use FlexOffsetDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultFlexOffsetDirective extends FlexOffsetDirective {
-  protected override inputs = inputs;
-}
-
 const flexOffsetCacheRowRtl: Map<string, StyleDefinition> = new Map();
 const flexOffsetCacheColumnRtl: Map<string, StyleDefinition> = new Map();
 const flexOffsetCacheRowLtr: Map<string, StyleDefinition> = new Map();

--- a/projects/libs/flex-layout/flex/flex-order/flex-order.spec.ts
+++ b/projects/libs/flex-layout/flex/flex-order/flex-order.spec.ts
@@ -21,7 +21,7 @@ import {
   makeCreateTestComponent,
 } from '@ngbracket/ngx-layout/_private-utils/testing';
 import { FlexLayoutModule } from '../../module';
-import { DefaultFlexOrderDirective } from '@ngbracket/ngx-layout/flex';
+import { FlexOrderDirective } from '@ngbracket/ngx-layout/flex';
 
 describe('flex-order', () => {
   let fixture: ComponentFixture<any>;
@@ -96,7 +96,7 @@ describe('flex-order', () => {
   selector: 'test-layout',
   template: `<span>PlaceHolder Template HTML</span>`,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [CommonModule, DefaultFlexOrderDirective],
+  imports: [CommonModule, FlexOrderDirective],
 })
 class TestOrderComponent {
   constructor() {}

--- a/projects/libs/flex-layout/flex/flex-order/flex-order.ts
+++ b/projects/libs/flex-layout/flex/flex-order/flex-order.ts
@@ -69,11 +69,3 @@ export class FlexOrderDirective extends BaseDirective2 implements OnChanges {
 }
 
 const flexOrderCache: Map<string, StyleDefinition> = new Map();
-/**
- * @deprecated The DefaultFlexOrderDirective will be removed in version 21.
- * Use FlexOrderDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultFlexOrderDirective extends FlexOrderDirective {
-  protected override inputs = inputs;
-}

--- a/projects/libs/flex-layout/flex/flex/flex.spec.ts
+++ b/projects/libs/flex-layout/flex/flex/flex.spec.ts
@@ -28,11 +28,11 @@ import {
   StyleUtils,
 } from '@ngbracket/ngx-layout/core';
 import {
-  DefaultFlexDirective,
-  DefaultLayoutDirective,
+  FlexDirective,
+  LayoutDirective,
   FlexStyleBuilder,
 } from '@ngbracket/ngx-layout/flex';
-import { DefaultStyleDirective } from '@ngbracket/ngx-layout/extended';
+import { StyleDirective } from '@ngbracket/ngx-layout/extended';
 
 describe('flex directive', () => {
   let fixture: ComponentFixture<any>;
@@ -1037,7 +1037,7 @@ describe('flex directive', () => {
       fixture = TestBed.createComponent(TestQueryWithFlexComponent);
       fixture.detectChanges();
 
-      const layout: DefaultLayoutDirective =
+      const layout: LayoutDirective =
         fixture.debugElement.componentInstance.layout;
 
       expect(layout).toBeDefined();
@@ -1063,8 +1063,7 @@ describe('flex directive', () => {
       fixture = TestBed.createComponent(TestQueryWithFlexComponent);
       fixture.detectChanges();
 
-      const flex: DefaultFlexDirective =
-        fixture.debugElement.componentInstance.flex;
+      const flex: FlexDirective = fixture.debugElement.componentInstance.flex;
 
       // Test for percentage value assignments
       expect(flex).toBeDefined();
@@ -1095,8 +1094,7 @@ describe('flex directive', () => {
       fixture = TestBed.createComponent(TestQueryWithFlexComponent);
       fixture.detectChanges();
 
-      const flex: DefaultFlexDirective =
-        fixture.debugElement.componentInstance.flex;
+      const flex: FlexDirective = fixture.debugElement.componentInstance.flex;
 
       // Test for raw value assignments that are converted to percentages
       expect(flex).toBeDefined();
@@ -1309,12 +1307,7 @@ export class MockFlexStyleBuilder extends StyleBuilder {
   selector: 'test-layout',
   template: `<span>PlaceHolder Template HTML</span>`,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [
-    CommonModule,
-    DefaultLayoutDirective,
-    DefaultFlexDirective,
-    DefaultStyleDirective,
-  ],
+  imports: [CommonModule, LayoutDirective, FlexDirective, StyleDirective],
 })
 class TestFlexComponent {
   direction = 'column';
@@ -1329,11 +1322,11 @@ class TestFlexComponent {
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [CommonModule, DefaultLayoutDirective, DefaultFlexDirective],
+  imports: [CommonModule, LayoutDirective, FlexDirective],
 })
 class TestQueryWithFlexComponent {
-  @ViewChild(DefaultFlexDirective, { static: true })
-  flex!: DefaultFlexDirective;
-  @ViewChild(DefaultLayoutDirective, { static: true })
-  layout!: DefaultLayoutDirective;
+  @ViewChild(FlexDirective, { static: true })
+  flex!: FlexDirective;
+  @ViewChild(LayoutDirective, { static: true })
+  layout!: LayoutDirective;
 }

--- a/projects/libs/flex-layout/flex/flex/flex.ts
+++ b/projects/libs/flex-layout/flex/flex/flex.ts
@@ -343,15 +343,6 @@ export class FlexDirective extends BaseDirective2 implements OnInit {
   }
 }
 
-/**
- * @deprecated The DefaultFlexDirective will be removed in version 21.
- * Use FlexDirective directly instead.
- */
-@Directive({ inputs, selector })
-export class DefaultFlexDirective extends FlexDirective {
-  protected override inputs = inputs;
-}
-
 const flexRowCache: Map<string, StyleDefinition> = new Map();
 const flexColumnCache: Map<string, StyleDefinition> = new Map();
 const flexRowWrapCache: Map<string, StyleDefinition> = new Map();

--- a/projects/libs/flex-layout/flex/layout-align/layout-align.spec.ts
+++ b/projects/libs/flex-layout/flex/layout-align/layout-align.spec.ts
@@ -16,11 +16,11 @@ import {
 import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
 import { FlexLayoutModule } from '@ngbracket/ngx-layout';
 import {
-  DefaultFlexDirective,
-  DefaultFlexOffsetDirective,
-  DefaultLayoutAlignDirective,
-  DefaultLayoutDirective,
-  DefaultLayoutGapDirective,
+  FlexDirective,
+  FlexOffsetDirective,
+  LayoutAlignDirective,
+  LayoutDirective,
+  LayoutGapDirective,
 } from '@ngbracket/ngx-layout/flex';
 import { extendObject } from '@ngbracket/ngx-layout/_private-utils';
 import {
@@ -662,11 +662,11 @@ export class MockLayoutAlignStyleBuilder extends StyleBuilder {
   changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     CommonModule,
-    DefaultLayoutDirective,
-    DefaultLayoutAlignDirective,
-    DefaultFlexDirective,
-    DefaultFlexOffsetDirective,
-    DefaultLayoutGapDirective,
+    LayoutDirective,
+    LayoutAlignDirective,
+    FlexDirective,
+    FlexOffsetDirective,
+    LayoutGapDirective,
   ],
 })
 class TestLayoutAlignComponent implements OnInit {

--- a/projects/libs/flex-layout/flex/layout-align/layout-align.ts
+++ b/projects/libs/flex-layout/flex/layout-align/layout-align.ts
@@ -200,15 +200,6 @@ export class LayoutAlignDirective extends BaseDirective2 {
   }
 }
 
-/**
- * @deprecated The DefaultLayoutAlignDirective will be removed in version 21.
- * Use LayoutAlignDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultLayoutAlignDirective extends LayoutAlignDirective {
-  protected override inputs = inputs;
-}
-
 const layoutAlignHorizontalCache: Map<string, StyleDefinition> = new Map();
 const layoutAlignVerticalCache: Map<string, StyleDefinition> = new Map();
 const layoutAlignHorizontalRevCache: Map<string, StyleDefinition> = new Map();

--- a/projects/libs/flex-layout/flex/layout-gap/layout-gap.spec.ts
+++ b/projects/libs/flex-layout/flex/layout-gap/layout-gap.spec.ts
@@ -24,12 +24,12 @@ import {
 } from '@angular/core/testing';
 import { FlexLayoutModule } from '@ngbracket/ngx-layout';
 import {
-  DefaultFlexDirective,
-  DefaultFlexOrderDirective,
-  DefaultLayoutDirective,
-  DefaultLayoutGapDirective,
+  FlexDirective,
+  FlexOrderDirective,
+  LayoutDirective,
+  LayoutGapDirective,
 } from '@ngbracket/ngx-layout/flex';
-import { DefaultShowHideDirective } from '@ngbracket/ngx-layout/extended';
+import { ShowHideDirective } from '@ngbracket/ngx-layout/extended';
 import {
   expectEl,
   expectNativeEl,
@@ -915,11 +915,11 @@ export class MockLayoutGapStyleBuilder extends StyleBuilder {
   changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     CommonModule,
-    DefaultLayoutDirective,
-    DefaultLayoutGapDirective,
-    DefaultFlexDirective,
-    DefaultFlexOrderDirective,
-    DefaultShowHideDirective,
+    LayoutDirective,
+    LayoutGapDirective,
+    FlexDirective,
+    FlexOrderDirective,
+    ShowHideDirective,
   ],
 })
 class TestLayoutGapComponent implements OnInit {

--- a/projects/libs/flex-layout/flex/layout-gap/layout-gap.ts
+++ b/projects/libs/flex-layout/flex/layout-gap/layout-gap.ts
@@ -274,15 +274,6 @@ export class LayoutGapDirective
   protected observer?: MutationObserver;
 }
 
-/**
- * @deprecated The DefaultLayoutGapDirective will be removed in version 21.
- * Use LayoutGapDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultLayoutGapDirective extends LayoutGapDirective {
-  protected override inputs = inputs;
-}
-
 const GRID_SPECIFIER = ' grid';
 
 function buildGridPadding(value: string): StyleDefinition {

--- a/projects/libs/flex-layout/flex/layout/layout.ts
+++ b/projects/libs/flex-layout/flex/layout/layout.ts
@@ -93,14 +93,5 @@ export class LayoutDirective extends BaseDirective2 implements OnChanges {
   }
 }
 
-/**
- * @deprecated The DefaultLayoutDirective will be removed in version 21.
- * Use LayoutDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultLayoutDirective extends LayoutDirective {
-  protected override inputs = inputs;
-}
-
 type CacheMap = Map<string, StyleDefinition>;
 const cacheMap = new Map<string, CacheMap>();

--- a/projects/libs/flex-layout/flex/module.ts
+++ b/projects/libs/flex-layout/flex/module.ts
@@ -2,24 +2,24 @@ import { BidiModule } from '@angular/cdk/bidi';
 import { NgModule } from '@angular/core';
 import { CoreModule } from '@ngbracket/ngx-layout/core';
 
-import { DefaultFlexAlignDirective } from './flex-align/flex-align';
+import { FlexAlignDirective } from './flex-align/flex-align';
 import { FlexFillDirective } from './flex-fill/flex-fill';
-import { DefaultFlexOffsetDirective } from './flex-offset/flex-offset';
-import { DefaultFlexOrderDirective } from './flex-order/flex-order';
-import { DefaultFlexDirective } from './flex/flex';
-import { DefaultLayoutAlignDirective } from './layout-align/layout-align';
-import { DefaultLayoutGapDirective } from './layout-gap/layout-gap';
-import { DefaultLayoutDirective } from './layout/layout';
+import { FlexOffsetDirective } from './flex-offset/flex-offset';
+import { FlexOrderDirective } from './flex-order/flex-order';
+import { FlexDirective } from './flex/flex';
+import { LayoutAlignDirective } from './layout-align/layout-align';
+import { LayoutGapDirective } from './layout-gap/layout-gap';
+import { LayoutDirective } from './layout/layout';
 
 const ALL_DIRECTIVES = [
-  DefaultLayoutDirective,
-  DefaultLayoutGapDirective,
-  DefaultLayoutAlignDirective,
-  DefaultFlexOrderDirective,
-  DefaultFlexOffsetDirective,
+  LayoutDirective,
+  LayoutGapDirective,
+  LayoutAlignDirective,
+  FlexOrderDirective,
+  FlexOffsetDirective,
   FlexFillDirective,
-  DefaultFlexAlignDirective,
-  DefaultFlexDirective,
+  FlexAlignDirective,
+  FlexDirective,
 ];
 
 /**

--- a/projects/libs/flex-layout/grid/align-columns/align-columns.spec.ts
+++ b/projects/libs/flex-layout/grid/align-columns/align-columns.spec.ts
@@ -23,7 +23,7 @@ import {
 } from '@ngbracket/ngx-layout/_private-utils/testing';
 
 import { GridModule } from '../module';
-import { DefaultGridAlignColumnsDirective } from '@ngbracket/ngx-layout/grid';
+import { GridAlignColumnsDirective } from '@ngbracket/ngx-layout/grid';
 
 describe('align columns directive', () => {
   let fixture: ComponentFixture<any>;
@@ -429,7 +429,7 @@ describe('align columns directive', () => {
   selector: 'test-layout',
   template: `<span>PlaceHolder Template HTML</span>`,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [CommonModule, DefaultGridAlignColumnsDirective],
+  imports: [CommonModule, GridAlignColumnsDirective],
 })
 class TestAlignComponent implements OnInit {
   mainAxis = 'start';

--- a/projects/libs/flex-layout/grid/align-columns/align-columns.ts
+++ b/projects/libs/flex-layout/grid/align-columns/align-columns.ts
@@ -90,15 +90,6 @@ const alignColumnsInlineCache: Map<string, StyleDefinition> = new Map();
  * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-19
  * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-21
  */
-/**
- * @deprecated The DefaultGridAlignColumnsDirective will be removed in version 21.
- * Use GridAlignColumnsDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultGridAlignColumnsDirective extends GridAlignColumnsDirective {
-  protected override inputs = inputs;
-}
-
 function buildCss(align: string, inline: boolean): StyleDefinition {
   const css: { [key: string]: string } = {},
     [mainAxis, crossAxis] = align.split(' ');

--- a/projects/libs/flex-layout/grid/align-rows/align-rows.spec.ts
+++ b/projects/libs/flex-layout/grid/align-rows/align-rows.spec.ts
@@ -23,7 +23,7 @@ import {
 
 import { Platform } from '@angular/cdk/platform';
 import { GridModule } from '../module';
-import { DefaultGridAlignRowsDirective } from '@ngbracket/ngx-layout/grid';
+import { GridAlignRowsDirective } from '@ngbracket/ngx-layout/grid';
 
 describe('align rows directive', () => {
   let fixture: ComponentFixture<any>;
@@ -429,7 +429,7 @@ describe('align rows directive', () => {
   selector: 'test-layout',
   template: `<span>PlaceHolder Template HTML</span>`,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [CommonModule, DefaultGridAlignRowsDirective],
+  imports: [CommonModule, GridAlignRowsDirective],
 })
 class TestAlignComponent implements OnInit {
   mainAxis = 'start';

--- a/projects/libs/flex-layout/grid/align-rows/align-rows.ts
+++ b/projects/libs/flex-layout/grid/align-rows/align-rows.ts
@@ -90,15 +90,6 @@ const alignRowsInlineCache: Map<string, StyleDefinition> = new Map();
  * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-18
  * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-20
  */
-/**
- * @deprecated The DefaultGridAlignRowsDirective will be removed in version 21.
- * Use GridAlignRowsDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultGridAlignRowsDirective extends GridAlignRowsDirective {
-  protected override inputs = inputs;
-}
-
 function buildCss(align: string, inline: boolean): StyleDefinition {
   const css: { [key: string]: string } = {},
     [mainAxis, crossAxis] = align.split(' ');

--- a/projects/libs/flex-layout/grid/area/area.spec.ts
+++ b/projects/libs/flex-layout/grid/area/area.spec.ts
@@ -26,8 +26,8 @@ import {
 
 import { GridModule } from '../module';
 import {
-  DefaultGridAreaDirective,
-  DefaultGridAutoDirective,
+  GridAreaDirective,
+  GridAutoDirective,
 } from '@ngbracket/ngx-layout/grid';
 
 describe('grid area child directive', () => {
@@ -258,7 +258,7 @@ describe('grid area child directive', () => {
   selector: 'test-layout',
   template: `<span>PlaceHolder Template HTML</span>`,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [CommonModule, DefaultGridAreaDirective, DefaultGridAutoDirective],
+  imports: [CommonModule, GridAreaDirective, GridAutoDirective],
 })
 class TestGridAreaComponent {
   area = 'sidebar';

--- a/projects/libs/flex-layout/grid/area/area.ts
+++ b/projects/libs/flex-layout/grid/area/area.ts
@@ -39,6 +39,11 @@ const selector = `
   [gdArea.gt-xs], [gdArea.gt-sm], [gdArea.gt-md], [gdArea.gt-lg]
 `;
 
+/**
+ * 'grid-area' CSS Grid styling directive
+ * Configures the name or position of an element within the grid
+ * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-27
+ */
 @Directive({ selector, inputs })
 export class GridAreaDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-area';
@@ -58,17 +63,3 @@ export class GridAreaDirective extends BaseDirective2 {
 }
 
 const gridAreaCache: Map<string, StyleDefinition> = new Map();
-
-/**
- * 'grid-area' CSS Grid styling directive
- * Configures the name or position of an element within the grid
- * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-27
- */
-/**
- * @deprecated The DefaultGridAreaDirective will be removed in version 21.
- * Use GridAreaDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultGridAreaDirective extends GridAreaDirective {
-  protected override inputs = inputs;
-}

--- a/projects/libs/flex-layout/grid/areas/areas.spec.ts
+++ b/projects/libs/flex-layout/grid/areas/areas.spec.ts
@@ -24,8 +24,8 @@ import {
 
 import { GridModule } from '../module';
 import {
-  DefaultGridAreaDirective,
-  DefaultGridAreasDirective,
+  GridAreaDirective,
+  GridAreasDirective,
 } from '@ngbracket/ngx-layout/grid';
 
 describe('grid area parent directive', () => {
@@ -250,7 +250,7 @@ describe('grid area parent directive', () => {
   selector: 'test-layout',
   template: `<span>PlaceHolder Template HTML</span>`,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [CommonModule, DefaultGridAreasDirective, DefaultGridAreaDirective],
+  imports: [CommonModule, GridAreasDirective, GridAreaDirective],
 })
 class TestGridAreaComponent {
   areas = 'sidebar | sidebar';

--- a/projects/libs/flex-layout/grid/areas/areas.ts
+++ b/projects/libs/flex-layout/grid/areas/areas.ts
@@ -53,6 +53,11 @@ const selector = `
   [gdAreas.gt-xs], [gdAreas.gt-sm], [gdAreas.gt-md], [gdAreas.gt-lg]
 `;
 
+/**
+ * 'grid-template-areas' CSS Grid styling directive
+ * Configures the names of elements within the grid
+ * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-14
+ */
 @Directive({ selector, inputs })
 export class GridAreasDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-areas';
@@ -89,17 +94,3 @@ export class GridAreasDirective extends BaseDirective2 {
 
 const areasCache: Map<string, StyleDefinition> = new Map();
 const areasInlineCache: Map<string, StyleDefinition> = new Map();
-
-/**
- * 'grid-template-areas' CSS Grid styling directive
- * Configures the names of elements within the grid
- * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-14
- */
-/**
- * @deprecated The DefaultGridAreasDirective will be removed in version 21.
- * Use GridAreasDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultGridAreasDirective extends GridAreasDirective {
-  protected override inputs = inputs;
-}

--- a/projects/libs/flex-layout/grid/auto/auto.spec.ts
+++ b/projects/libs/flex-layout/grid/auto/auto.spec.ts
@@ -21,8 +21,8 @@ import {
   StyleUtils,
 } from '@ngbracket/ngx-layout/core';
 import {
-  DefaultGridAreaDirective,
-  DefaultGridAutoDirective,
+  GridAreaDirective,
+  GridAutoDirective,
   GridModule,
 } from '@ngbracket/ngx-layout/grid';
 
@@ -322,7 +322,7 @@ describe('grid auto parent directive', () => {
   selector: 'test-layout',
   template: `<span>PlaceHolder Template HTML</span>`,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [CommonModule, DefaultGridAutoDirective, DefaultGridAreaDirective],
+  imports: [CommonModule, GridAutoDirective, GridAreaDirective],
 })
 class TestGridAutoComponent {
   auto = 'row';

--- a/projects/libs/flex-layout/grid/auto/auto.ts
+++ b/projects/libs/flex-layout/grid/auto/auto.ts
@@ -58,6 +58,11 @@ const selector = `
   [gdAuto.gt-xs], [gdAuto.gt-sm], [gdAuto.gt-md], [gdAuto.gt-lg]
 `;
 
+/**
+ * 'grid-auto-flow' CSS Grid styling directive
+ * Configures the auto placement algorithm for the grid
+ * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-23
+ */
 @Directive({ selector, inputs })
 export class GridAutoDirective extends BaseDirective2 {
   @Input('gdInline')
@@ -94,17 +99,3 @@ export class GridAutoDirective extends BaseDirective2 {
 
 const autoCache: Map<string, StyleDefinition> = new Map();
 const autoInlineCache: Map<string, StyleDefinition> = new Map();
-
-/**
- * 'grid-auto-flow' CSS Grid styling directive
- * Configures the auto placement algorithm for the grid
- * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-23
- */
-/**
- * @deprecated The DefaultGridAutoDirective will be removed in version 21.
- * Use GridAutoDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultGridAutoDirective extends GridAutoDirective {
-  protected override inputs = inputs;
-}

--- a/projects/libs/flex-layout/grid/column/column.spec.ts
+++ b/projects/libs/flex-layout/grid/column/column.spec.ts
@@ -25,9 +25,9 @@ import {
 
 import { GridModule } from '../module';
 import {
-  DefaultGridAreaDirective,
-  DefaultGridAutoDirective,
-  DefaultGridColumnDirective,
+  GridAreaDirective,
+  GridAutoDirective,
+  GridColumnDirective,
 } from '@ngbracket/ngx-layout/grid';
 
 describe('grid column child directive', () => {
@@ -199,9 +199,9 @@ describe('grid column child directive', () => {
   changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     CommonModule,
-    DefaultGridAutoDirective,
-    DefaultGridColumnDirective,
-    DefaultGridAreaDirective,
+    GridAutoDirective,
+    GridColumnDirective,
+    GridAreaDirective,
   ],
 })
 class TestGridColumnComponent {

--- a/projects/libs/flex-layout/grid/column/column.ts
+++ b/projects/libs/flex-layout/grid/column/column.ts
@@ -40,6 +40,11 @@ const selector = `
   [gdColumn.gt-xs], [gdColumn.gt-sm], [gdColumn.gt-md], [gdColumn.gt-lg]
 `;
 
+/**
+ * 'grid-column' CSS Grid styling directive
+ * Configures the name or position of an element within the grid
+ * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-26
+ */
 @Directive({ selector, inputs })
 export class GridColumnDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-column';
@@ -59,17 +64,3 @@ export class GridColumnDirective extends BaseDirective2 {
 }
 
 const columnCache: Map<string, StyleDefinition> = new Map();
-
-/**
- * 'grid-column' CSS Grid styling directive
- * Configures the name or position of an element within the grid
- * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-26
- */
-/**
- * @deprecated The DefaultGridColumnDirective will be removed in version 21.
- * Use GridColumnDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultGridColumnDirective extends GridColumnDirective {
-  protected override inputs = inputs;
-}

--- a/projects/libs/flex-layout/grid/columns/columns.spec.ts
+++ b/projects/libs/flex-layout/grid/columns/columns.spec.ts
@@ -24,8 +24,8 @@ import {
 
 import { GridModule } from '../module';
 import {
-  DefaultGridAreaDirective,
-  DefaultGridColumnsDirective,
+  GridAreaDirective,
+  GridColumnsDirective,
 } from '@ngbracket/ngx-layout/grid';
 
 describe('grid columns parent directive', () => {
@@ -222,11 +222,7 @@ describe('grid columns parent directive', () => {
   selector: 'test-layout',
   template: `<span>PlaceHolder Template HTML</span>`,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [
-    CommonModule,
-    DefaultGridColumnsDirective,
-    DefaultGridAreaDirective,
-  ],
+  imports: [CommonModule, GridColumnsDirective, GridAreaDirective],
 })
 class TestGridColumnsComponent {
   cols = '50px 1fr';

--- a/projects/libs/flex-layout/grid/columns/columns.ts
+++ b/projects/libs/flex-layout/grid/columns/columns.ts
@@ -61,6 +61,12 @@ const selector = `
   [gdColumns.gt-xs], [gdColumns.gt-sm], [gdColumns.gt-md], [gdColumns.gt-lg]
 `;
 
+/**
+ * 'grid-template-columns' CSS Grid styling directive
+ * Configures the sizing for the columns in the grid
+ * Syntax: <column value> [auto]
+ * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-13
+ */
 @Directive({ selector, inputs })
 export class GridColumnsDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-columns';
@@ -97,18 +103,3 @@ export class GridColumnsDirective extends BaseDirective2 {
 
 const columnsCache: Map<string, StyleDefinition> = new Map();
 const columnsInlineCache: Map<string, StyleDefinition> = new Map();
-
-/**
- * 'grid-template-columns' CSS Grid styling directive
- * Configures the sizing for the columns in the grid
- * Syntax: <column value> [auto]
- * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-13
- */
-/**
- * @deprecated The DefaultGridColumnsDirective will be removed in version 21.
- * Use GridColumnsDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultGridColumnsDirective extends GridColumnsDirective {
-  protected override inputs = inputs;
-}

--- a/projects/libs/flex-layout/grid/gap/gap.spec.ts
+++ b/projects/libs/flex-layout/grid/gap/gap.spec.ts
@@ -23,7 +23,7 @@ import {
 } from '@ngbracket/ngx-layout/_private-utils/testing';
 
 import { GridModule } from '../module';
-import { DefaultGridGapDirective } from '@ngbracket/ngx-layout/grid';
+import { GridGapDirective } from '@ngbracket/ngx-layout/grid';
 
 describe('grid gap directive', () => {
   let fixture: ComponentFixture<any>;
@@ -310,7 +310,7 @@ describe('grid gap directive', () => {
   selector: 'test-layout',
   template: `<span>PlaceHolder Template HTML</span>`,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [CommonModule, DefaultGridGapDirective],
+  imports: [CommonModule, GridGapDirective],
 })
 class TestLayoutGapComponent {
   gap = '8px';

--- a/projects/libs/flex-layout/grid/gap/gap.ts
+++ b/projects/libs/flex-layout/grid/gap/gap.ts
@@ -48,6 +48,12 @@ const selector = `
   [gdGap.gt-xs], [gdGap.gt-sm], [gdGap.gt-md], [gdGap.gt-lg]
 `;
 
+/**
+ * 'grid-gap' CSS Grid styling directive
+ * Configures the gap between items in the grid
+ * Syntax: <row gap> [<column-gap>]
+ * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-17
+ */
 @Directive({ selector, inputs })
 export class GridGapDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-gap';
@@ -84,18 +90,3 @@ export class GridGapDirective extends BaseDirective2 {
 
 const gapCache: Map<string, StyleDefinition> = new Map();
 const gapInlineCache: Map<string, StyleDefinition> = new Map();
-
-/**
- * 'grid-gap' CSS Grid styling directive
- * Configures the gap between items in the grid
- * Syntax: <row gap> [<column-gap>]
- * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-17
- */
-/**
- * @deprecated The DefaultGridGapDirective will be removed in version 21.
- * Use GridGapDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultGridGapDirective extends GridGapDirective {
-  protected override inputs = inputs;
-}

--- a/projects/libs/flex-layout/grid/grid-align/grid-align.spec.ts
+++ b/projects/libs/flex-layout/grid/grid-align/grid-align.spec.ts
@@ -23,7 +23,7 @@ import {
   makeCreateTestComponent,
 } from '@ngbracket/ngx-layout/_private-utils/testing';
 import { FlexLayoutModule } from '../../module';
-import { DefaultGridAlignDirective } from '@ngbracket/ngx-layout/grid';
+import { GridAlignDirective } from '@ngbracket/ngx-layout/grid';
 
 describe('align directive', () => {
   let fixture: ComponentFixture<any>;
@@ -380,7 +380,7 @@ describe('align directive', () => {
   selector: 'test-layout',
   template: `<span>PlaceHolder Template HTML</span>`,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [CommonModule, DefaultGridAlignDirective],
+  imports: [CommonModule, GridAlignDirective],
 })
 class TestAlignComponent implements OnInit {
   mainAxis = 'start';

--- a/projects/libs/flex-layout/grid/grid-align/grid-align.ts
+++ b/projects/libs/flex-layout/grid/grid-align/grid-align.ts
@@ -69,15 +69,6 @@ const alignCache: Map<string, StyleDefinition> = new Map();
  *  @see https://css-tricks.com/snippets/css/complete-guide-grid/#prop-justify-self
  *  @see https://css-tricks.com/snippets/css/complete-guide-grid/#prop-align-self
  */
-/**
- * @deprecated The DefaultGridAlignDirective will be removed in version 21.
- * Use GridAlignDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultGridAlignDirective extends GridAlignDirective {
-  protected override inputs = inputs;
-}
-
 function buildCss(align: string = '') {
   const css: { [key: string]: string } = {},
     [rowAxis, columnAxis] = align.split(' ');

--- a/projects/libs/flex-layout/grid/module.ts
+++ b/projects/libs/flex-layout/grid/module.ts
@@ -1,30 +1,30 @@
 import { NgModule } from '@angular/core';
 import { CoreModule } from '@ngbracket/ngx-layout/core';
 
-import { DefaultGridAlignColumnsDirective } from './align-columns/align-columns';
-import { DefaultGridAlignRowsDirective } from './align-rows/align-rows';
-import { DefaultGridAreaDirective } from './area/area';
-import { DefaultGridAreasDirective } from './areas/areas';
-import { DefaultGridAutoDirective } from './auto/auto';
-import { DefaultGridColumnDirective } from './column/column';
-import { DefaultGridColumnsDirective } from './columns/columns';
-import { DefaultGridGapDirective } from './gap/gap';
-import { DefaultGridAlignDirective } from './grid-align/grid-align';
-import { DefaultGridRowDirective } from './row/row';
-import { DefaultGridRowsDirective } from './rows/rows';
+import { GridAlignColumnsDirective } from './align-columns/align-columns';
+import { GridAlignRowsDirective } from './align-rows/align-rows';
+import { GridAreaDirective } from './area/area';
+import { GridAreasDirective } from './areas/areas';
+import { GridAutoDirective } from './auto/auto';
+import { GridColumnDirective } from './column/column';
+import { GridColumnsDirective } from './columns/columns';
+import { GridGapDirective } from './gap/gap';
+import { GridAlignDirective } from './grid-align/grid-align';
+import { GridRowDirective } from './row/row';
+import { GridRowsDirective } from './rows/rows';
 
 const ALL_DIRECTIVES = [
-  DefaultGridAlignDirective,
-  DefaultGridAlignColumnsDirective,
-  DefaultGridAlignRowsDirective,
-  DefaultGridAreaDirective,
-  DefaultGridAreasDirective,
-  DefaultGridAutoDirective,
-  DefaultGridColumnDirective,
-  DefaultGridColumnsDirective,
-  DefaultGridGapDirective,
-  DefaultGridRowDirective,
-  DefaultGridRowsDirective,
+  GridAlignDirective,
+  GridAlignColumnsDirective,
+  GridAlignRowsDirective,
+  GridAreaDirective,
+  GridAreasDirective,
+  GridAutoDirective,
+  GridColumnDirective,
+  GridColumnsDirective,
+  GridGapDirective,
+  GridRowDirective,
+  GridRowsDirective,
 ];
 
 /**

--- a/projects/libs/flex-layout/grid/row/row.spec.ts
+++ b/projects/libs/flex-layout/grid/row/row.spec.ts
@@ -25,9 +25,9 @@ import {
 
 import { GridModule } from '../module';
 import {
-  DefaultGridAreaDirective,
-  DefaultGridAutoDirective,
-  DefaultGridRowDirective,
+  GridAreaDirective,
+  GridAutoDirective,
+  GridRowDirective,
 } from '@ngbracket/ngx-layout/grid';
 
 describe('grid row child directive', () => {
@@ -198,9 +198,9 @@ describe('grid row child directive', () => {
   changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     CommonModule,
-    DefaultGridAutoDirective,
-    DefaultGridRowDirective,
-    DefaultGridAreaDirective,
+    GridAutoDirective,
+    GridRowDirective,
+    GridAreaDirective,
   ],
 })
 class TestGridRowComponent {

--- a/projects/libs/flex-layout/grid/row/row.ts
+++ b/projects/libs/flex-layout/grid/row/row.ts
@@ -40,6 +40,11 @@ const selector = `
   [gdRow.gt-xs], [gdRow.gt-sm], [gdRow.gt-md], [gdRow.gt-lg]
 `;
 
+/**
+ * 'grid-row' CSS Grid styling directive
+ * Configures the name or position of an element within the grid
+ * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-26
+ */
 @Directive({ selector, inputs })
 export class GridRowDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-row';
@@ -59,17 +64,3 @@ export class GridRowDirective extends BaseDirective2 {
 }
 
 const rowCache: Map<string, StyleDefinition> = new Map();
-
-/**
- * 'grid-row' CSS Grid styling directive
- * Configures the name or position of an element within the grid
- * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-26
- */
-/**
- * @deprecated The DefaultGridRowDirective will be removed in version 21.
- * Use GridRowDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultGridRowDirective extends GridRowDirective {
-  protected override inputs = inputs;
-}

--- a/projects/libs/flex-layout/grid/rows/rows.spec.ts
+++ b/projects/libs/flex-layout/grid/rows/rows.spec.ts
@@ -24,8 +24,8 @@ import {
 
 import { GridModule } from '../module';
 import {
-  DefaultGridAreaDirective,
-  DefaultGridRowsDirective,
+  GridAreaDirective,
+  GridRowsDirective,
 } from '@ngbracket/ngx-layout/grid';
 
 describe('grid rows parent directive', () => {
@@ -222,7 +222,7 @@ describe('grid rows parent directive', () => {
   selector: 'test-layout',
   template: `<span>PlaceHolder Template HTML</span>`,
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [CommonModule, DefaultGridRowsDirective, DefaultGridAreaDirective],
+  imports: [CommonModule, GridRowsDirective, GridAreaDirective],
 })
 class TestGridRowsComponent {
   cols = '50px 1fr';

--- a/projects/libs/flex-layout/grid/rows/rows.ts
+++ b/projects/libs/flex-layout/grid/rows/rows.ts
@@ -61,6 +61,12 @@ const selector = `
   [gdRows.gt-xs], [gdRows.gt-sm], [gdRows.gt-md], [gdRows.gt-lg]
 `;
 
+/**
+ * 'grid-template-rows' CSS Grid styling directive
+ * Configures the sizing for the rows in the grid
+ * Syntax: <column value> [auto]
+ * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-13
+ */
 @Directive({ selector, inputs })
 export class GridRowsDirective extends BaseDirective2 {
   protected override DIRECTIVE_KEY = 'grid-rows';
@@ -97,18 +103,3 @@ export class GridRowsDirective extends BaseDirective2 {
 
 const rowsCache: Map<string, StyleDefinition> = new Map();
 const rowsInlineCache: Map<string, StyleDefinition> = new Map();
-
-/**
- * 'grid-template-rows' CSS Grid styling directive
- * Configures the sizing for the rows in the grid
- * Syntax: <column value> [auto]
- * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-13
- */
-/**
- * @deprecated The DefaultGridRowsDirective will be removed in version 21.
- * Use GridRowsDirective directly instead.
- */
-@Directive({ selector, inputs })
-export class DefaultGridRowsDirective extends GridRowsDirective {
-  protected override inputs = inputs;
-}


### PR DESCRIPTION
## Summary

Completes the cleanup promised in the v21 standalone migration. The `Default<X>Directive` classes were all marked *"@deprecated … will be removed in version 21"* but were never actually removed (we're on v22). They're **redundant subclasses** — the base directives already carry the identical `selector` and `inputs`:

```ts
@Directive({ inputs, selector })
export class FlexDirective extends BaseDirective2 { … }   // fully functional

@Directive({ inputs, selector })                          // same selector/inputs
export class DefaultFlexDirective extends FlexDirective { // adds nothing
  protected override inputs = inputs;
}
```

So they add nothing but a duplicate public symbol.

## Changes

- Removed all **22** `Default*` directives across `flex/`, `extended/`, `grid/`.
- Repointed the **FlexModule / ExtendedModule / GridModule** (and all specs + the universal-demo `split-area.directive.ts`) to the base directives (`DefaultFlexDirective` → `FlexDirective`, etc.).
- Moved the grid directive **descriptions** that were attached to the `Default*` classes onto their base directives, so no API docs are lost.
- The public API auto-drops the symbols (entry points re-export via wildcards).

The **NgModules are intentionally kept** — that's a separate, larger breaking change for another PR.

## Breaking change

The deprecated `Default*` directives are gone. Consumers replace each `Default<X>Directive` with `<X>Directive` (e.g. `DefaultFlexDirective` → `FlexDirective`). Base directives have identical selectors and behavior, so it's a pure symbol rename — no template or behavior changes.

## Verification

- `ng test @ngbracket/ngx-layout` — **478 tests pass**
- `ng build @ngbracket/ngx-layout` — clean (no duplicate-identifier / type errors)
- `ng build universal-demo-app` & `ng build updated-demo` — both build clean (covers the directive-injection usage in the universal demo)

Net **−231 lines** (414 deletions / 183 insertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)